### PR TITLE
Return response if custom error handler is used

### DIFF
--- a/discohook/handler.py
+++ b/discohook/handler.py
@@ -102,11 +102,8 @@ async def handler(request: Request):
             return JSONResponse({"message": "unhandled interaction type"}, status_code=300)
     except Exception as e:
         if request.app.error_handler:
-            response = await request.app.error_handler(interaction, e)
-            if isinstance(response, Response):
-              return response
-            else:
-              return Response(status_code=500)
+            await request.app.error_handler(interaction, e)
+            return JSONResponse({"message": "internal server error"}, status_code=500)
         else:
             err = ''.join(traceback.format_exception(type(e), e, e.__traceback__))
             raise RuntimeError(err) from None

--- a/discohook/handler.py
+++ b/discohook/handler.py
@@ -102,7 +102,11 @@ async def handler(request: Request):
             return JSONResponse({"message": "unhandled interaction type"}, status_code=300)
     except Exception as e:
         if request.app.error_handler:
-            await request.app.error_handler(interaction, e)
+            response = await request.app.error_handler(interaction, e)
+            if isinstance(response, Response):
+              return response
+            else:
+              return Response(status_code=500)
         else:
             err = ''.join(traceback.format_exception(type(e), e, e.__traceback__))
             raise RuntimeError(err) from None


### PR DESCRIPTION
So right now if we set a custom error handler, we'll always get this message each time the app hits an error:
```py
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/home/imp/rPlace/venv/lib/python3.9/site-packages/uvicorn/protocols/http/h11_impl.py", line 428, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
  File "/home/imp/rPlace/venv/lib/python3.9/site-packages/uvicorn/middleware/proxy_headers.py", line 78, in __call__
    return await self.app(scope, receive, send)
  File "/home/imp/rPlace/venv/lib/python3.9/site-packages/fastapi/applications.py", line 276, in __call__
    await super().__call__(scope, receive, send)
  File "/home/imp/rPlace/venv/lib/python3.9/site-packages/starlette/applications.py", line 122, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/home/imp/rPlace/venv/lib/python3.9/site-packages/starlette/middleware/errors.py", line 184, in __call__
    raise exc
  File "/home/imp/rPlace/venv/lib/python3.9/site-packages/starlette/middleware/errors.py", line 162, in __call__
    await self.app(scope, receive, _send)
  File "/home/imp/rPlace/venv/lib/python3.9/site-packages/starlette/middleware/exceptions.py", line 79, in __call__
    raise exc
  File "/home/imp/rPlace/venv/lib/python3.9/site-packages/starlette/middleware/exceptions.py", line 68, in __call__
    await self.app(scope, receive, sender)
  File "/home/imp/rPlace/venv/lib/python3.9/site-packages/fastapi/middleware/asyncexitstack.py", line 21, in __call__
    raise e
  File "/home/imp/rPlace/venv/lib/python3.9/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "/home/imp/rPlace/venv/lib/python3.9/site-packages/starlette/routing.py", line 718, in __call__
    await route.handle(scope, receive, send)
  File "/home/imp/rPlace/venv/lib/python3.9/site-packages/starlette/routing.py", line 276, in handle
    await self.app(scope, receive, send)
  File "/home/imp/rPlace/venv/lib/python3.9/site-packages/starlette/routing.py", line 69, in app
    await response(scope, receive, send)
TypeError: 'NoneType' object is not callable
```
The error message above is pretty useless, the way to get hide it is by raising an exception or returning a response. So this PR returns a generic 500 Internal Server Error response or returns a custom response returned from the user defined error handler.

You could make it return `JSONResponse({"message": "internal server error"}, status_code=500)` instead of `Response(status_code=500)` so it's more consistent with this line https://github.com/imptype/discohook/blob/patch-5/discohook/handler.py#L102