### PR TITLE
Global interaction `before_invoke`, `after_invoke`, `check` decorators

### DIFF
--- a/discohook/client.py
+++ b/discohook/client.py
@@ -83,6 +83,9 @@ class Client(FastAPI):
         )
         self.error_handler: Optional[Callable] = None
         self._custom_id_parser: Optional[Callable] = None
+        self._before_invoke: Optional[Callable] = None
+        self._after_invoke: Optional[Callable] = None
+        self._interaction_check: Optional[Callable] = None
 
     def load_components(self, view: View):
         """
@@ -205,6 +208,33 @@ class Client(FastAPI):
         coro: Callable
         """
         self._custom_id_parser = coro
+        
+    def before_invoke(self, coro: Callable):
+        """
+        A decorator to register a dev defined interactions pre-invoke hook.
+        Parameters
+        ----------
+        coro: Callable
+        """
+        self._before_invoke = coro
+        
+    def after_invoke(self, coro: Callable):
+        """
+        A decorator to register a dev defined interactions post-invoke hook.
+        Parameters
+        ----------
+        coro: Callable
+        """
+        self._after_invoke = coro
+        
+    def interaction_check(self, coro: Callable):
+        """
+        A decorator to register a dev defined global interactions check to determine if interactions should be processed or not.
+        Parameters
+        ----------
+        coro: Callable
+        """
+        self._interactions_check = coro
 
     async def send_message(
         self,

--- a/discohook/handler.py
+++ b/discohook/handler.py
@@ -39,76 +39,85 @@ async def handler(request: Request):
     data = await request.json()
     interaction = Interaction(data, request.app)
     try:
-        if interaction.type == InteractionType.ping:
-            return JSONResponse({"type": InteractionCallbackType.pong.value}, status_code=200)
-
-        elif interaction.type == InteractionType.app_command:
-            key = f"{interaction.data['name']}:{interaction.data['type']}"
-            cmd: ApplicationCommand = request.app.application_commands.get(key)
-            if not cmd:
-                raise RuntimeError(f"command `{interaction.data['name']}` ({interaction.data['id']}) not found")
-
-            elif not (interaction.data["type"] == ApplicationCommandType.slash.value):
-                target_object = build_context_menu_param(interaction)
-                await cmd.__call__(interaction, target_object)
-
-            elif interaction.data.get("options") and (
-                interaction.data["options"][0]["type"] == ApplicationCommandOptionType.subcommand.value
-            ):
-                subcommand = cmd.subcommands[interaction.data["options"][0]["name"]]
-                args, kwargs = build_slash_command_prams(subcommand.callback, interaction)
-                await subcommand.__call__(interaction, *args, **kwargs)
-            else:
-                args, kwargs = build_slash_command_prams(cmd.callback, interaction)
-                await cmd.__call__(interaction, *args, **kwargs)
-
-        elif interaction.type == InteractionType.autocomplete:
-            key = f"{interaction.data['name']}:{interaction.data['type']}"
-            cmd: ApplicationCommand = request.app.application_commands.get(key)
-            if not cmd:
-                return JSONResponse({"error": "command not found"}, status_code=404)
-            option_type = interaction.data["options"][0]["type"]
-            if option_type == ApplicationCommandOptionType.subcommand.value:
-                subcommand_name = interaction.data["options"][0]["name"]
-                option = interaction.data["options"][0]["options"][0]
-                callback = cmd.subcommands[subcommand_name].autocompletes.get(option["name"])
-            else:
-                option = interaction.data["options"][0]
-                callback = cmd.autocompletes.get(option["name"])
-            if callback:
-                await callback(interaction, option["value"])
-
-        elif interaction.type in (InteractionType.component, InteractionType.modal_submit):
-            custom_id = interaction.data["custom_id"]
-            if request.app._custom_id_parser:
-                custom_id = await request.app._custom_id_parser(custom_id)
-            component = request.app.active_components.get(custom_id)
-            if not component:
-                return JSONResponse({"error": "component not found"}, status_code=404)
+        if not request.app.interaction_check or await request.app.interaction_check(interaction):
             
-            if interaction.type == InteractionType.component:
-                if interaction.data["component_type"] == MessageComponentType.button.value:
-                    await component.__call__(interaction)
-                menu_types = [
-                    MessageComponentType.text_select.value,
-                    MessageComponentType.user_select.value,
-                    MessageComponentType.role_select.value,
-                    MessageComponentType.channel_select.value,
-                    MessageComponentType.mentionable_select.value,
-                ]
-                if interaction.data["component_type"] in menu_types:
-                    await component.__call__(interaction, build_select_menu_values(interaction))
-                    
-            elif interaction.type == InteractionType.modal_submit:
-                args, kwargs = build_modal_params(component.callback, interaction)
-                await component.__call__(interaction, *args, **kwargs)
+            if request.app.before_invoke:
+                await request.app.before_invoke(interaction)
+
+            if interaction.type == InteractionType.ping:
+                return JSONResponse({"type": InteractionCallbackType.pong.value}, status_code=200)
+
+            elif interaction.type == InteractionType.app_command:
+                key = f"{interaction.data['name']}:{interaction.data['type']}"
+                cmd: ApplicationCommand = request.app.application_commands.get(key)
+                if not cmd:
+                    raise RuntimeError(f"command `{interaction.data['name']}` ({interaction.data['id']}) not found")
+
+                elif not (interaction.data["type"] == ApplicationCommandType.slash.value):
+                    target_object = build_context_menu_param(interaction)
+                    await cmd.__call__(interaction, target_object)
+
+                elif interaction.data.get("options") and (
+                    interaction.data["options"][0]["type"] == ApplicationCommandOptionType.subcommand.value
+                ):
+                    subcommand = cmd.subcommands[interaction.data["options"][0]["name"]]
+                    args, kwargs = build_slash_command_prams(subcommand.callback, interaction)
+                    await subcommand.__call__(interaction, *args, **kwargs)
+                else:
+                    args, kwargs = build_slash_command_prams(cmd.callback, interaction)
+                    await cmd.__call__(interaction, *args, **kwargs)
+
+            elif interaction.type == InteractionType.autocomplete:
+                key = f"{interaction.data['name']}:{interaction.data['type']}"
+                cmd: ApplicationCommand = request.app.application_commands.get(key)
+                if not cmd:
+                    return JSONResponse({"error": "command not found"}, status_code=404)
+                option_type = interaction.data["options"][0]["type"]
+                if option_type == ApplicationCommandOptionType.subcommand.value:
+                    subcommand_name = interaction.data["options"][0]["name"]
+                    option = interaction.data["options"][0]["options"][0]
+                    callback = cmd.subcommands[subcommand_name].autocompletes.get(option["name"])
+                else:
+                    option = interaction.data["options"][0]
+                    callback = cmd.autocompletes.get(option["name"])
+                if callback:
+                    await callback(interaction, option["value"])
+
+            elif interaction.type in (InteractionType.component, InteractionType.modal_submit):
+                custom_id = interaction.data["custom_id"]
+                if request.app._custom_id_parser:
+                    custom_id = await request.app._custom_id_parser(custom_id)
+                component = request.app.active_components.get(custom_id)
+                if not component:
+                    return JSONResponse({"error": "component not found"}, status_code=404)
+
+                if interaction.type == InteractionType.component:
+                    if interaction.data["component_type"] == MessageComponentType.button.value:
+                        await component.__call__(interaction)
+                    menu_types = [
+                        MessageComponentType.text_select.value,
+                        MessageComponentType.user_select.value,
+                        MessageComponentType.role_select.value,
+                        MessageComponentType.channel_select.value,
+                        MessageComponentType.mentionable_select.value,
+                    ]
+                    if interaction.data["component_type"] in menu_types:
+                        await component.__call__(interaction, build_select_menu_values(interaction))
+
+                elif interaction.type == InteractionType.modal_submit:
+                    args, kwargs = build_modal_params(component.callback, interaction)
+                    await component.__call__(interaction, *args, **kwargs)
+
+            else:
+                return JSONResponse({"message": "unhandled interaction type"}, status_code=300)
+            
+            if request.app.after_invoke:
+                await request.app.after_invoke(interaction)
                 
-        else:
-            return JSONResponse({"message": "unhandled interaction type"}, status_code=300)
-    except Exception as exc:
-        stack_trace = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
-        if request.app.error_handler:
-            await request.app.error_handler(interaction, exc)
-            return JSONResponse({"errors": stack_trace}, status_code=500)
-        raise RuntimeError(stack_trace) from None
+        except Exception as exc:
+            stack_trace = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+            if request.app.error_handler:
+                await request.app.error_handler(interaction, exc)
+                return JSONResponse({"errors": stack_trace}, status_code=500)
+            raise RuntimeError(stack_trace) from None
     return Response(status_code=200)


### PR DESCRIPTION
This adds these decorators, with some use case examples:
```py
@app.before_invoke
async def before_invoke(interaction):
  # code to run before interaction callback
  print(f'{interaction.author} started an {interaction.type}')
  app.cache['users'][interaction.author.id] = interaction.author
  if interaction.guild_id:
    app.cache['guilds'][interaction.guild_id] = interaction.guild

@app.after_invoke
async def after_invoke(interaction):
  # code to run after interaction callback
  text = f'{interaction.author} finished an {interaction.type}'
  log_channel_id = 970435058181750810
  await app.send_message(log_channel_id, text[:2000])

@app.interaction_check
async def interaction_check(interaction):
  # must return True if the interaction should be processed
  if interaction.from_originator:
    return True
  await interaction.response(f'{interaction.author.mention} This is not your interaction!', ephemeral = True)
```