### PR TITLE
Made button label optional

### DIFF
--- a/discohook/view.py
+++ b/discohook/view.py
@@ -77,6 +77,8 @@ class Button(Component):
         emoji: Optional[Union[str, PartialEmoji]] = None,
         custom_id: Optional[str] = None,
     ):
+        if not label and not emoji:
+            raise ValueError('Buttons must have either a label or emoji, they can\'t be blank.')
         super().__init__(ComponentType.button, custom_id)
         self.url = url
         self.label = label
@@ -101,7 +103,7 @@ class Button(Component):
     @classmethod
     def new(
         cls,
-        label: str,
+        label: Optional[str] = None,
         *,
         style: ButtonStyle = ButtonStyle.blurple,
         disabled: bool = False,
@@ -113,7 +115,7 @@ class Button(Component):
 
         Parameters
         ----------
-        label: str
+        label: str | None
             The text to be displayed on the button.
         style: :class:`ButtonStyle`
             The style of the button.


### PR DESCRIPTION
Changes:
- Made the `label` parameter optional for `__init__()` and `new()`.
- Added a check for `not label` and `not emoji` in `__init__()`, since you can't have a button without both label and emoji.

This lets you skip writing `None` for buttons that don't have a label, like for my stop button:

before:
```py
@discohook.Button.new(None, emoji = '🗑️', style = discohook.ButtonStyle.red, custom_id = 'help_stop:v0.0')
async def stop_button(interaction):
  await interaction.response.update_message(view = None)
```

after:
```py
@discohook.Button.new(emoji = '🗑️', style = discohook.ButtonStyle.red, custom_id = 'help_stop:v0.0')
async def stop_button(interaction):
  await interaction.response.update_message(view = None)
```