### PR TITLE
Return response in webhook methods

### DIFF
--- a/discohook/webhook.py
+++ b/discohook/webhook.py
@@ -76,7 +76,7 @@ class PartialWebhook:
         if view:
             self.client.load_components(view)
         form = create_form(payload, merge_fields(file, files))
-        await self.client.http.execute_webhook(self.id, self.token, form=form)
+        return await self.client.http.execute_webhook(self.id, self.token, form=form)
 
 
 class Webhook:
@@ -271,7 +271,7 @@ class Webhook:
         if view:
             self.client.load_components(view)
         form = create_form(payload, merge_fields(file, files))
-        await self.client.http.send_webhook_message(self.id, self.token, form)
+        return await self.client.http.send_webhook_message(self.id, self.token, form)
 
     async def edit_message(
         self,


### PR DESCRIPTION
I added `return` so we can tell the difference between `204` or `404`. This won't work for methods that return stuff already like `edit_message`. Imo you should test [response codes](https://discord.com/developers/docs/topics/opcodes-and-status-codes#http-http-response-codes) and raise specific errors like 404 Not Found, 403 Forbidden, etc. with their own custom classes so we can `try & except` them when we need to. Maybe a [`_raise_or_return`](https://github.com/jnsougata/deta.py/blob/main/deta/errors.py#L94C11-L110) function like in the other library?