### PR TITLE
Add support for premium apps

### DIFF
--- a/discohook/adapter.py
+++ b/discohook/adapter.py
@@ -271,6 +271,20 @@ class ResponseAdapter:
         self.inter._responded = True
         return InteractionResponse(self.inter)
 
+   async def require_premium(self):
+        """
+        Prompts the user that a premium purchase is required for this interaction
+        This method is only available for applications with a premium SKU set up
+        """
+        if self.inter.kind == InteractionType.autocomplete:
+            raise InteractionTypeMismatch(f"Method not supported for {self.inter.kind}")
+        payload = {
+            "data": {},
+            "type": InteractionCallbackType.premium_required,
+        }
+        self.inter._responded = True
+        await self.inter.client.http.send_interaction_callback(self.inter.id, self.inter.token, payload)
+
     async def update_message(
         self,
         content: Optional[str] = MISSING,

--- a/discohook/adapter.py
+++ b/discohook/adapter.py
@@ -271,7 +271,7 @@ class ResponseAdapter:
         self.inter._responded = True
         return InteractionResponse(self.inter)
 
-   async def require_premium(self):
+    async def require_premium(self):
         """
         Prompts the user that a premium purchase is required for this interaction
         This method is only available for applications with a premium SKU set up

--- a/discohook/enums.py
+++ b/discohook/enums.py
@@ -170,6 +170,7 @@ class InteractionCallbackType(int, Enum):
     update_component_message = 7
     autocomplete = 8
     modal = 9
+    premium_required = 10
 
 
 class ComponentType(int, Enum):

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -208,3 +208,18 @@ class HTTPClient:
         if emoji:
             path += f"/{emoji}"
         return await self.request("DELETE", path, use_auth=True)
+        
+    async def create_test_entitlement(self, application_id: str, payload: Dict[str, Any]):
+        return await self.request("POST", f"/applications/{application_id}/entitlements", json=payload, use_auth=True)
+
+    async def delete_test_entitlement(self, application_id: str, entitlement_id: str):
+        return await self.request("DELETE", f"/applications/{application_id}/entitlements/{entitlement_id}", use_auth=True)
+
+    async def fetch_entitlement(self, application_id: str, entitlement_id: str):
+        return await self.request("GET", f"/applications/{application_id}/entitlements/{entitlement_id}", use_auth=True)
+
+    async def fetch_entitlements(self, application_id: str, params: Dict[str, Any]):
+        return await self.request("GET", f"/applications/{application_id}/entitlements", params=params, use_auth=True)
+
+    async def fetch_skus(self, application_id: str):
+        return await self.request("GET", f"/applications/{application_id}/skus", use_auth=True)


### PR DESCRIPTION
I added an `InteractionResponse.require_premium()` method so we can respond to an interaction with [PREMIUM_REQUIRED (type 10)][1] which basically spawns an "upgrade" button for people:

![image](https://github.com/jnsougata/discohook/assets/106537315/5a0c2372-38d8-491f-badd-2f8554f73133)
![image](https://github.com/jnsougata/discohook/assets/106537315/1257b7c6-6f9d-4ae9-8e53-1720805d6c43)

Note that if your app does not have an SKU then `require_premium()` results in this:
```json
{
  "message": "Invalid Form Body",
  "code": 50035,
  "errors": {
    "type": {
      "_errors": [
        {
          "code": "BASE_TYPE_CHOICES",
          "message": "Value must be one of {1, 4, 5, 6, 7, 8, 9, 11}."
        }
      ]
    }
  }
}
```
which means you can't test on a test bot, you actually have to do it on your verified bot itself.

I also added 5 other http methods to [help test if your premium features work][2].
```py
params = {}
data = await interaction.client.http.fetch_entitlements(interaction.client.application_id, params)
# https://discord.com/developers/docs/monetization/entitlements#list-entitlements
# returns a list of entitlement objects if any, the params are trivial

data = await interaction.client.http.fetch_entitlement(interaction.client.application_id, '1167178975399923803')
# https://discord.com/developers/docs/monetization/entitlements#entitlement-object-entitlement-example
# returns an entitlement object if it exists or 404

payload = {
  'sku_id' : '1164677752927043584',
  'owner_id' : '970435058181750814',
  'owner_type': 1
}
data = await interaction.client.http.create_test_entitlement(interaction.client.application_id, payload)
# https://discord.com/developers/docs/monetization/entitlements#create-test-entitlement
# returns an entitlement object or errors if you did it wrong

await interaction.client.http.delete_test_entitlement(interaction.client.application_id, '1167178975399923803')
# https://discord.com/developers/docs/monetization/entitlements#delete-test-entitlement
# returns 204 if success or 404 if not found

data = await interaction.client.http.fetch_skus(interaction.client.application_id)
# https://discord.com/developers/docs/monetization/skus#list-skus
# returns a list of sku objects if any

# btw http errors are silent so you have to print to find them
```
and then we can implement premium features by checking `interaction.payload` to see if they own the sku, something like this:
```py
def has_premium(interaction):
  entitlements = interaction.payload.get('entitlements')
  for i in entitlements:
    if i['sku_id'] == '1164677752927043584':
      return True
  return False

@discohook.command.slash('test', description = 'test stuff')
async def test_command(interaction):
  if has_premium(interaction):
    await interaction.response.send('You have premium!')
  else:
    await interaction.response.send('You don\'t have premium.')
```

[1]: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-interaction-callback-type
[2]: https://discord.com/developers/docs/monetization/entitlements


