### PR TITLE
Made `Embed.to_dict()` use `get` instead

### DIFF
--- a/discohook/embed.py
+++ b/discohook/embed.py
@@ -65,12 +65,12 @@ class Embed:
         """
         embed = cls()
         embed.data = data
-        embed.title = data.pop("title", None)
-        embed.description = data.pop("description", None)
-        embed.url = data.pop("url", None)
-        embed.color = data.pop("color", None)
-        embed.timestamp = data.pop("timestamp", None)
-        embed.fields = data.pop("fields", [])
+        embed.title = data.get("title")
+        embed.description = data.get("description")
+        embed.url = data.get("url")
+        embed.color = data.get("color")
+        embed.timestamp = data.get("timestamp")
+        embed.fields = data.get("fields", [])
         return embed
 
     def set_author(self, *, name: str, url: Optional[str] = None, icon_url: Optional[str] = None):


### PR DESCRIPTION
use .get() instead of .pop() because it interferes if you access/use the payload again;
```py
async def start_button(interaction):
  print(interaction.message.embeds[0].to_dict()) # returns {'color': 3066993, 'description': 'test', 'title': 'Maze Lobby', 'type': 'rich'}
  embed = interaction.message.embeds
  print(interaction.message.embeds[0].to_dict()) # returns {'type': 'rich'}
```