### PR TITLE
Add string option to autocomplete

### DIFF
--- a/discohook/option.py
+++ b/discohook/option.py
@@ -184,8 +184,7 @@ class Option:
                 self.kind in
                 (
                     ApplicationCommandOptionType.integer,
-                    ApplicationCommandOptionType.number,
-                    ApplicationCommandOptionType.string
+                    ApplicationCommandOptionType.number
                 )
         ):
             if self.autocomplete is not None:
@@ -195,6 +194,8 @@ class Option:
             if self.min_value is not None:
                 self.data["min_value"] = self.min_value
         if self.kind == ApplicationCommandOptionType.string:
+            if self.autocomplete is not None:
+                self.data["autocomplete"] = self.autocomplete
             if self.max_length:
                 self.data["max_length"] = self.max_length
             if self.min_length:

--- a/discohook/option.py
+++ b/discohook/option.py
@@ -184,7 +184,8 @@ class Option:
                 self.kind in
                 (
                     ApplicationCommandOptionType.integer,
-                    ApplicationCommandOptionType.number
+                    ApplicationCommandOptionType.number,
+                    ApplicationCommandOptionType.string
                 )
         ):
             if self.autocomplete is not None:


### PR DESCRIPTION
Autocomplete supports `STRING` option:
![image](https://github.com/jnsougata/discohook/assets/106537315/9d433355-6d94-4d4e-989f-e8558d365451)

Right now a command that has an autocomplete string option would just be ignored (the option payload is `autocomplete=False`)
```py
@discohook.command.slash('test', description = 'test stuff', guild_id = SUPPORT_SERVER_ID, options = [
  discohook.Option.string('choice', 'Type and select a choice.', autocomplete = True)
])
async def test_command(interaction):
  await interaction.response.send('content')

@test_command.autocomplete(name = 'choice')
async def choice_autocomplete(interaction, value):
  print('here!')
  await interaction.response.autocomplete([])
```
after this commit, syncing makes the option payload `autocomplete=True` because it passes that if check