### PR TITLE
Fix focused autocomplete option

### DIFF
--- a/discohook/handler.py
+++ b/discohook/handler.py
@@ -89,7 +89,9 @@ async def _handler(request: Request):
                 option = interaction.data["options"][0]["options"][0]
                 callback = cmd.subcommands[subcommand_name].autocompletes.get(option["name"])
             else:
-                option = interaction.data["options"][0]
+                for option in interaction.data["options"]:
+                  if "focused" in option:
+                    break
                 callback = cmd.autocompletes.get(option["name"])
             if callback:
                 await callback(interaction, option["value"])


### PR DESCRIPTION
Right now the handler for autocomplete always uses the first option (index  `[0]`), when it should use the `focused : True` field instead:
![image](https://github.com/jnsougata/discohook/assets/106537315/38488c20-2084-431c-bf81-40c0ff9239ad)
So the autocomplete for the example code below, where it has 2 options and the autocomplete is the second option, the autocomplete's callback will never be found because it uses index `[0]` instead of `focused : true`.
```py
@discohook.command.slash('test', description = 'test stuff', guild_id = SUPPORT_SERVER_ID, options = [
  discohook.Option.integer('number', 'Select a number between 1 to 5.', choices = [
    discohook.Choice(name = str(i), value = i) 
    for i in range(1, 6)
  ]),
  discohook.Option.string('choice', 'Type and select a choice.', autocomplete = True)
])
async def test_command(interaction):
  await interaction.response.send('content')

@test_command.autocomplete('choice')
async def choice_autocomplete(interaction, value):
  print('here!', value)
  await interaction.response.autocomplete([])
```
This commit fixes this bug but I noticed the same issue probably exists in autocompletes for subcommands:
```py
            if interaction.data["options"][0]["type"] == ApplicationCommandOptionType.subcommand:
                subcommand_name = interaction.data["options"][0]["name"]
                option = interaction.data["options"][0]["options"][0]
                callback = cmd.subcommands[subcommand_name].autocompletes.get(option["name"])
```
It looks like it assumes the index `[0]` twice instead of using `focused`? That may need to be fixed too...
