### PR TITLE
Fix autocomplete choices to_dict

### DIFF
--- a/discohook/adapter.py
+++ b/discohook/adapter.py
@@ -233,7 +233,7 @@ class ResponseAdapter:
         if self.inter.kind != InteractionType.autocomplete:
             raise InteractionTypeMismatch(f"Method not supported for {self.inter.kind}")
         choices = choices[:25]
-        payload = {"type": InteractionCallbackType.autocomplete, "data": {"choices": choices}}
+        payload = {"type": InteractionCallbackType.autocomplete, "data": {"choices": [i.to_dict() for i in choices]}}
         await self.inter.client.http.send_interaction_callback(self.inter.id, self.inter.token, payload)
 
     async def defer(self, ephemeral: bool = False) -> InteractionResponse:


### PR DESCRIPTION
It gives this error otherwise:
```py
  File "/usr/lib/python3.9/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
        {'self': <json.encoder.JSONEncoder object at 0x7ded979f1fa0>, 'o': <discohook.option.Choice object at 0x7ded9604d190>}
  File "/usr/lib/python3.9/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type Choice is not JSON serializable
```