### PR TITLE
Remove ! from member mention

### DIFF
--- a/discohook/member.py
+++ b/discohook/member.py
@@ -66,7 +66,7 @@ class Member(User):
         """
         Returns a string that allows you to mention the member.
         """
-        return f"<@!{self.id}>"
+        return f"<@{self.id}>"
 
     def has_permission(self, permission: Permission) -> bool:
         return Permission.check(self.permissions, permission)


### PR DESCRIPTION
https://discord.com/developers/docs/reference#message-formatting
![image](https://github.com/jnsougata/discohook/assets/106537315/4b0f4c5d-5444-4dd4-a01e-f9d6bee65bdb)

The issue is already fixed with `User` too:
![image](https://github.com/jnsougata/discohook/assets/106537315/070bf122-3d54-4d05-a446-1f87b3b6ca4f)
