### PR TITLE
Fix default avatar url

### DIFF
--- a/discohook/asset.py
+++ b/discohook/asset.py
@@ -21,6 +21,8 @@ class Asset:
     def __str__(self) -> str:
         if self.dynamic:
             return f"{self.base_url}/{self._fragment}/{self._hash}.gif?size=1024"
+        if self.default:
+            return f"{self.base_url}/{self._fragment}/{self._hash}.png"
         return f"{self.base_url}/{self._fragment}/{self._hash}.webp?size=1024"
 
     @property
@@ -34,6 +36,17 @@ class Asset:
         """
         return self._hash.startswith("a_")
 
+    @property
+    def default(self) -> bool:
+        """
+        Checks if the asset is a default avatar.
+
+        Returns
+        -------
+        :class:`bool`
+        """
+        return len(self._hash) == 1
+        
     @property
     def url(self) -> str:
         """

--- a/discohook/user.py
+++ b/discohook/user.py
@@ -77,7 +77,7 @@ class User:
         if av_hash:
             return Asset(hash=av_hash, fragment=f"avatars/{self.id}")
         if self.discriminator == 0:
-            av_hash = str({(int(self.id) >> 22) % 6})
+            av_hash = str((int(self.id) >> 22) % 6)
         else:
             av_hash = str(int(self.discriminator) % 5)
         return Asset(hash=av_hash, fragment="embed/avatars")


### PR DESCRIPTION
Default avatar URLs right now are:
```
https://cdn.discordapp.com/embed/avatars/2.webp?size=1024
```
or if using the new username system:
```
https://cdn.discordapp.com/embed/avatars/{2}.webp?size=1024
```
due to that `{}` typo. Either way, both urls are invalid and this PR fixes both of them.