### PR TITLE
Return response object for other methods

### DIFF
--- a/discohook/adapter.py
+++ b/discohook/adapter.py
@@ -220,6 +220,8 @@ class ResponseAdapter:
             "type": InteractionCallbackType.modal,
         }
         await self.inter.client.http.send_interaction_callback(self.inter.id, self.inter.token, payload)
+        self.inter._responded = True
+        return InteractionResponse(self.inter)
 
     async def autocomplete(self, choices: List[Choice]):
         """
@@ -270,8 +272,9 @@ class ResponseAdapter:
             "data": {},
             "type": InteractionCallbackType.premium_required,
         }
-        self.inter._responded = True
         await self.inter.client.http.send_interaction_callback(self.inter.id, self.inter.token, payload)
+        self.inter._responded = True
+        return InteractionResponse(self.inter)
 
     async def update_message(
         self,
@@ -325,6 +328,8 @@ class ResponseAdapter:
             self.inter.client.load_components(view)
         payload = payload.to_form(InteractionCallbackType.update_component_message)
         return await self.inter.client.http.send_interaction_mp_callback(self.inter.id, self.inter.token, payload)
+        self.inter._responded = True
+        return InteractionResponse(self.inter)
 
     async def followup(
         self,


### PR DESCRIPTION
Currently `ResponseAdapter.send() and .defer()` return an `InteractionResponse` object which we can do webhook edits/deletes on. This is also possible to do after using these methods `.send_modal() .require_premium() .update_message()` so I made those methods return an `InteractionResponse` object in this commit. In other words, this isn't possible for `AUTOCOMPLETE` and `PING` interactions because those are a one time thing.

Try this example code for reference:
```py
import discohook

@discohook.button.new('test')
async def test_button(interaction):
  await interaction.response.update_message('updated message')
  response = discohook.InteractionResponse(interaction)
  await response.edit('followup edit') # <- this is possible

@discohook.command.slash('test', description = 'Test stuff!')
async def test_command(interaction):
  view = discohook.View()
  view.add_buttons(test_button)
  await interaction.response.send('test!', view = view)
```

Also something else to think about: Shouldn't `ResponseAdapter.followup()` be moved to `InteractionResponse.followup()` because it uses a webhook and is pretty much a `webhook.send()`? It's the odd one out in `ResponseAdapter` because all the other methods there `.send() .send_modal() .autocomplete() .defer() .require_premium() .update_message()` all use `/interactions/{interaction.id}/{interaction.token}/callback` except for `followup()` which uses `webhook/.../@original` like the other methods in `InteractionResponse`.