### PR TITLE
Add HTTPException error

### DIFF
--- a/discohook/errors.py
+++ b/discohook/errors.py
@@ -20,3 +20,12 @@ class UnknownInteractionType(Exception):
     def __init__(self, message: str):
         self.message = message
         super().__init__(message)
+
+
+class HTTPException(Exception):
+    """Raised when an HTTP request operation fails."""
+    
+    def __init__(self, resp, message):
+        self.resp = resp
+        self.message = message
+        super().init__(message)

--- a/discohook/errors.py
+++ b/discohook/errors.py
@@ -28,4 +28,4 @@ class HTTPException(Exception):
     def __init__(self, resp, message):
         self.resp = resp
         self.message = message
-        super().init__(message)
+        super().__init__(message)


### PR DESCRIPTION
Currently, no HTTP errors are raised for 4xx or 5xx codes.

For example, if you do something like this:

```py
text = 'a' * 2001 # <- goes beyond max 2000 chars in message content
await interaction.response.send(text)
```
Nothing happens, the bot doesn't send a message and no errors are raised. The only way to know why it didn't work is to go deep in `adapter.py` or `https.py` and print the response json to know your payload was bad, which makes this hard to debug. This would be a massive QOL improvement.

Also, I think `async def request()` and `async def multipart()` in `https.py` could be merged into 1 method?