### PR TITLE
Lazy http instantiation

### DIFF
--- a/discohook/client.py
+++ b/discohook/client.py
@@ -108,6 +108,7 @@ class Client(Starlette):
         self.active_components: Dict[str, Component] = {}
         self._sync_queue: List[ApplicationCommand] = []
         self.commands: Dict[str, ApplicationCommand] = {}
+        self._http = None # This will be created on first request
         self.add_route(route, _handler, methods=["POST"], include_in_schema=False)
         self.add_route("/api/sync", sync, methods=["POST"], include_in_schema=False)
         self.add_route("/api/dash", dashboard, methods=["GET"], include_in_schema=False)

--- a/discohook/client.py
+++ b/discohook/client.py
@@ -105,7 +105,6 @@ class Client(Starlette):
         self.public_key = public_key
         self.application_id = application_id
         self.password = password
-        self.http = HTTPClient(self, token, aiohttp.ClientSession("https://discord.com"))
         self.active_components: Dict[str, Component] = {}
         self._sync_queue: List[ApplicationCommand] = []
         self.commands: Dict[str, ApplicationCommand] = {}
@@ -119,6 +118,12 @@ class Client(Starlette):
             self.add_commands(_help)
         self._interaction_error_handler: Optional[Callable[[Interaction, Exception], Any]] = None
 
+    @property
+    def http(self):
+        if not self._http:
+            self._http = HTTPClient(self, token, aiohttp.ClientSession("https://discord.com"))
+        return self._http
+    
     def on_error(self):
         """
         A decorator to add an error handler for any server errors.

--- a/discohook/client.py
+++ b/discohook/client.py
@@ -122,7 +122,7 @@ class Client(Starlette):
     @property
     def http(self):
         if not self._http:
-            self._http = HTTPClient(self, token, aiohttp.ClientSession("https://discord.com"))
+            self._http = HTTPClient(self, self.token, aiohttp.ClientSession("https://discord.com"))
         return self._http
     
     def on_error(self):


### PR DESCRIPTION
Move Client.http to a cached property to allow lazy instantiation of the HTTPClient to the first use of it. This fixes discohook issues on serverless providers like Vercel which run the app in a pre-existing asyncio event loop. Deferring instantiation to the handling of the first request causes the aiohttp.ClientSession to re-use the event loop from the platform rather than creating its own which causes conflicts