### PR TITLE
Middleware to make a single use session per request

### DIFF
--- a/discohook/middleware.py
+++ b/discohook/middleware.py
@@ -1,0 +1,8 @@
+import aiohttp
+from starlette.middleware.base import BaseHTTPMiddleware
+
+class SingleUseSessionMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        await request.app.http.session.close()
+        request.app.http.session = aiohttp.ClientSession('https://discord.com')
+        return await call_next(request)

--- a/discohook/middleware.py
+++ b/discohook/middleware.py
@@ -2,6 +2,12 @@ import aiohttp
 from starlette.middleware.base import BaseHTTPMiddleware
 
 class SingleUseSessionMiddleware(BaseHTTPMiddleware):
+    """ This middleware creates a new aiohttp.ClientSession
+        to handle this request.
+        This is helpful for some serverless prviders
+        that handle each request in a new event loop
+        but keep the same app instance
+    """
     async def dispatch(self, request, call_next):
         await request.app.http.session.close()
         request.app.http.session = aiohttp.ClientSession('https://discord.com')


### PR DESCRIPTION
This middleware can be used for serverless providers, like vercel, that create a new event loop per request.

See [here](https://github.com/vercel/vercel/blob/c32a909afcedf0ee55777d5dcaecc0c8383dd8c8/packages/python/vc_init.py#L201)

This messes up discohook because the aiohttp.ClientSession gets created when the Client gets instantiated and it has a different event loop. An example of how a user can use the middleware is:

```py
from starlette.middleware import Middleware
from discohook.middleware import SingleUseSessionMiddleware

app = discohook.Client(
    application_id=APPLICATION_ID,
    token=APPLICATION_TOKEN,
    public_key=APPLICATION_PUBLIC_KEY,
    password=APPLICATION_PASSWORD,
    default_help_command=True,
    middleware=[Middleware(SingleUseSessionMiddleware)],
)
```