### PR TITLE
Fix member data

### DIFF
--- a/discohook/guild.py
+++ b/discohook/guild.py
@@ -6,6 +6,7 @@ from .enums import ChannelType
 from .permission import Permission
 from .role import Role
 from .member import Member
+from .utils import unwrap_user
 
 if TYPE_CHECKING:
     from .client import Client
@@ -37,8 +38,7 @@ class PartialGuild:
         data = await resp.json()
         if not data.get("user"):
             return
-        data["guild_id"] = self.id
-        return Member(self.client, data)
+        return Member(self.client, unwrap_user(data, self.id))
 
     async def fetch_channels(self) -> List[Channel]:
         """

--- a/discohook/interaction.py
+++ b/discohook/interaction.py
@@ -7,7 +7,7 @@ from .member import Member
 from .message import Message
 from .adapter import ResponseAdapter
 from .user import User
-from .utils import snowflake_time
+from .utils import snowflake_time, unwrap_user
 
 if TYPE_CHECKING:
     from .client import Client
@@ -246,8 +246,7 @@ class Interaction:
         """
         if not self.guild_id:
             return User(self.client, self.payload["user"])
-        self.payload["member"]["guild_id"] = self.guild_id
-        return Member(self.client, self.payload["member"])
+        return Member(self.client, unwrap_user(self.payload["member"], self.guild_id))
 
     @property
     def guild(self) -> Optional[PartialGuild]:

--- a/discohook/member.py
+++ b/discohook/member.py
@@ -15,7 +15,7 @@ class Member(User):
     """
 
     def __init__(self, client: "Client", data: Dict[str, Any]):
-        super().__init__(client, data["user"])
+        super().__init__(client, data)
 
     @property
     def guild_id(self) -> str:

--- a/discohook/resolver.py
+++ b/discohook/resolver.py
@@ -13,6 +13,7 @@ from .member import Member
 from .message import Message
 from .role import Role
 from .user import User
+from .utils import unwrap_user
 
 
 def handle_params_by_signature(

--- a/discohook/resolver.py
+++ b/discohook/resolver.py
@@ -71,7 +71,7 @@ def parse_generic_options(payload: List[Dict[str, Any]], interaction: Interactio
             if interaction.guild_id:
                 member_data = interaction.data["resolved"]["members"][value]
                 member_data["user"] = user_data
-                member_data["guild_id"] = interaction.guild_id
+                member_data = unwrap_user(member_data, interaction.guild_id)
                 options[name] = Member(interaction.client, member_data)
             else:
                 options[name] = User(interaction.client, user_data)

--- a/discohook/utils.py
+++ b/discohook/utils.py
@@ -31,3 +31,11 @@ def find_description(name: str, description: Any, callback: Handler) -> str:
     if callback.__doc__:
         return callback.__doc__.strip().split("\n")[0]
     raise ValueError(f"description is required for slash command `{name}`")
+
+
+def unwrap_user(data: dict, guild_id: str) -> dict:
+    member = json.loads(json.dumps(data))
+    user: dict = member.pop("user")
+    member.update(user)
+    member["guild_id"] = guild_id
+    return member


### PR DESCRIPTION
This reverts the commit https://github.com/jnsougata/discohook/commit/1c576e3 where it removed `unwrap_user()` and broke Member data.

E.g. this code errors:
```py
import discohook

@discohook.command.slash('test', description = 'Test stuff!')
async def test_command(interaction):
  await interaction.response.send('did /test')
  print(interaction.author.joined_at)
```
```
Traceback (most recent call last):
  File "/home/imp/rPlace/venv/lib/python3.9/site-packages/discohook/handler.py", line 80, in _handler
    raise e
  File "/home/imp/rPlace/venv/lib/python3.9/site-packages/discohook/handler.py", line 77, in _handler
    await cmd(interaction, *args, **kwargs)
  File "/home/imp/rPlace/src/cogs/test.py", line 6, in test_command
    print(interaction.author.joined_at)
  File "/home/imp/rPlace/venv/lib/python3.9/site-packages/discohook/member.py", line 35, in joined_at
    return self.data["joined_at"]
KeyError: 'joined_at'
```