### PR TITLE
Remove atexit and initialize session in async context

### DIFF
--- a/discohook/client.py
+++ b/discohook/client.py
@@ -1,5 +1,4 @@
 import asyncio
-import atexit
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import aiohttp
@@ -117,11 +116,6 @@ class Client(Starlette):
         self.application_id = application_id
         self.password = password
         session = aiohttp.ClientSession("https://discord.com")
-
-        @atexit.register
-        def close_session():
-            asyncio.get_event_loop().run_until_complete(session.close())
-
         self.http = HTTPClient(self, token, session)
         self.active_components: Dict[str, Component] = {}
         self._sync_queue: List[ApplicationCommand] = []

--- a/discohook/client.py
+++ b/discohook/client.py
@@ -115,8 +115,7 @@ class Client(Starlette):
         self.public_key = public_key
         self.application_id = application_id
         self.password = password
-        session = aiohttp.ClientSession("https://discord.com")
-        self.http = HTTPClient(self, token, session)
+        self.http = HTTPClient(self, token)
         self.active_components: Dict[str, Component] = {}
         self._sync_queue: List[ApplicationCommand] = []
         self.commands: Dict[str, ApplicationCommand] = {}

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -13,10 +13,10 @@ class HTTPClient:
 
     DISCORD_API_VERSION: int = 10
 
-    def __init__(self, client: "Client", token: str, session: aiohttp.ClientSession):
+    def __init__(self, client: "Client", token: str):
         self.token = token
         self.client = client
-        self.session = session
+        self.session: Optional[aiohttp.ClientSession] = None
 
     async def request(
         self,
@@ -40,6 +40,8 @@ class HTTPClient:
         if form:
             for key, value in headers.items():
                 form.headers.add(key, value)
+        if self.session:
+            self.session = aiohttp.ClientSession("https://discord.com")
         resp = await self.session.request(
             method,
             f"/api/v{self.DISCORD_API_VERSION}{path}",

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -40,7 +40,7 @@ class HTTPClient:
         if form:
             for key, value in headers.items():
                 form.headers.add(key, value)
-        if self.session:
+        if not self.session:
             self.session = aiohttp.ClientSession("https://discord.com")
         resp = await self.session.request(
             method,


### PR DESCRIPTION
1. The `atexit` code is useless. It runs after the event loop is closed, so the code:
```py
        @atexit.register
        def close_session():
            asyncio.get_event_loop().run_until_complete(session.close())
```
will just give a `RuntimeError: no running event loop` error.

2. Create `aiohttp.ClientSession()` in the first async function instead of in `__init__`. This is because for platforms like Vercel, where every new request enters from a sync context (so there is no other way), it says `session is closed`, because it was created using an event loop that is now closed.