### PR TITLE
middleware.py check session exists before closing

### DIFF
--- a/discohook/middleware.py
+++ b/discohook/middleware.py
@@ -12,6 +12,7 @@ class SingleUseSession(BaseHTTPMiddleware):
     """
 
     async def dispatch(self, request: Request, rre: RequestResponseEndpoint):
-        await request.app.http.session.close()
+        if request.app.http.session:
+            await request.app.http.session.close()
         request.app.http.session = aiohttp.ClientSession("https://discord.com")
         return await rre(request)


### PR DESCRIPTION
A change by @imptype around 2 weeks ago delayed the creation of the session which caused this middleware to fail cause session was none. In any case it's good to have this check here because can't close a non created session