### PR TITLE
Fix HTTPException message

### DIFF
--- a/discohook/errors.py
+++ b/discohook/errors.py
@@ -30,7 +30,15 @@ class UnknownInteractionType(Exception):
 class HTTPException(Exception):
     """Raised when an HTTP request operation fails."""
 
-    def __init__(self, resp: aiohttp.ClientResponse, data: Any):
+    def __init__(self, resp: aiohttp.ClientResponse, message: str):
         self.resp = resp
-        message = f"[{resp.status} {resp.method}] {resp.url.path}\n{data}"
         super().__init__(message)
+
+    @classmethod
+    async def create(cls, resp: aiohttp.ClientResponse):
+        if resp.headers.get("content-type") == "application/json":
+            data = await resp.json()
+        else:
+            data = await resp.text()
+        message = f"[{resp.status} {resp.method}] {resp.url.path}\n{data}"
+        return cls(resp, message)

--- a/discohook/errors.py
+++ b/discohook/errors.py
@@ -32,5 +32,5 @@ class HTTPException(Exception):
 
     def __init__(self, resp: aiohttp.ClientResponse, data: Any):
         self.resp = resp
-        message = f"[{resp.method}] {resp.url.path} {resp.status} with code({data['code']}): {data['message']}"
+        message = f"[{resp.status} {resp.method}] {resp.url.path}\n{data}"
         super().__init__(message)

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -51,7 +51,11 @@ class HTTPClient:
             json=json,
         )
         if resp.status >= 400:
-            raise HTTPException(resp, await resp.json())
+            if resp.headers.get("content-type") == "application/json":
+                text = await resp.json()
+            else:
+                text = await resp.text()
+            raise HTTPException(resp, text)
         return resp
 
     async def fetch_application(self):

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -51,11 +51,7 @@ class HTTPClient:
             json=json,
         )
         if resp.status >= 400:
-            if resp.headers.get("content-type") == "application/json":
-                text = await resp.json()
-            else:
-                text = await resp.text()
-            raise HTTPException(resp, text)
+            raise await HTTPException.create(resp)
         return resp
 
     async def fetch_application(self):


### PR DESCRIPTION
1. Fix HTTPException erroring when getting content types other than `application/json`.
![image](https://github.com/user-attachments/assets/b69ec582-f855-468e-b496-01ce47e0a433)

2. Be more explicit with the response data. Sometimes it doesn't have the "code" key in it, but it is a valid json.
![image](https://github.com/user-attachments/assets/3f16c76d-9e51-4302-8203-cfee4bdeb3c0)
