### PR TITLE
fix user arg resolver

### DIFF
--- a/discohook/resolver.py
+++ b/discohook/resolver.py
@@ -67,7 +67,7 @@ def parse_generic_options(payload: List[Dict[str, Any]], interaction: Interactio
                 interaction.focused_option_name = name
         elif option_type == ApplicationCommandOptionType.user:
             user_data = interaction.data["resolved"]["users"][value]
-            if interaction.guild_id:
+            if interaction.guild_id and "members" in interaction.data["resolved"]:
                 member_data = interaction.data["resolved"]["members"][value]
                 member_data["user"] = user_data
                 member_data = unwrap_user(member_data, interaction.guild_id)


### PR DESCRIPTION
If you have a slash command like this:
```py
@discohook.command.slash('profile', description = 'view a profile', options = [
  discohook.Option.user('user', 'View this user\'s profile.')
])
```
You could send the argument as:
1. a member object, by typing and selecting `@imptype` from an autocomplete list of results, and it means this user exists in your server
2. alternatively, you could also type a user id directly which means this user doesn't have to be in your server

when we do the latter, discord gives us the user data object but not member object, so this pr fixes this error
![image](https://github.com/user-attachments/assets/07de0dda-1956-469f-8628-db6dc855d8f2)
![image](https://github.com/user-attachments/assets/3e68f97e-7ae6-46b3-b502-0e05b580e733)

p.s. discord automatically detects if we type an invalid user id
![image](https://github.com/user-attachments/assets/5999dd41-97ae-47e7-beae-e00169f77a85)

