### PR TITLE
Redo http methods

### DIFF
--- a/discohook/channel.py
+++ b/discohook/channel.py
@@ -107,7 +107,7 @@ class PartialChannel:
             message_reference=message_reference,
         )
 
-        resp = await self.client.http.send_message(self.id, payload)
+        resp = await self.client.http.create_message(self.id, payload)
         data = await resp.json()
         return Message(self.client, data)
 

--- a/discohook/channel.py
+++ b/discohook/channel.py
@@ -331,7 +331,7 @@ class PartialChannel:
         await self.client.http.delete_or_close_channel(self.id, reason=reason)
 
     async def crosspost(self, message_id: str):
-        resp = await self.client.http.crosspost_channel_message(self.id, message_id)
+        resp = await self.client.http.crosspost_message(self.id, message_id)
         data = await resp.json()
         return Message(self.client, data)
 

--- a/discohook/channel.py
+++ b/discohook/channel.py
@@ -327,7 +327,7 @@ class PartialChannel:
         return messages
 
     async def delete(self):
-        await self.client.http.delete_channel(self.id)
+        await self.client.http.delete_or_close_channel(self.id)
 
     async def crosspost(self, message_id: str):
         resp = await self.client.http.crosspost_channel_message(self.id, message_id)

--- a/discohook/channel.py
+++ b/discohook/channel.py
@@ -134,6 +134,7 @@ class PartialChannel:
         default_thread_rate_limit_per_user: Optional[int] = None,
         default_sort_order: Optional[int] = None,
         default_forum_layout: Optional[int] = None,
+        reason: Optional[str] = None
     ) -> "Channel":
         """
         Edits all kinds of channels.
@@ -229,7 +230,7 @@ class PartialChannel:
             payload["default_sort_order"] = default_sort_order
         if default_forum_layout:
             payload["default_forum_layout"] = default_forum_layout
-        resp = await self.client.http.modify_channel(self.id, payload)
+        resp = await self.client.http.modify_channel(self.id, payload, reason=reason)
         data = await resp.json()
         return Channel(self.client, data)
 

--- a/discohook/channel.py
+++ b/discohook/channel.py
@@ -296,6 +296,7 @@ class PartialChannel:
         before: Optional[str] = None,
         after: Optional[str] = None,
         around: Optional[str] = None,
+        reason: Optional[str] = None
     ) -> List[Message]:
         """
         Deletes messages from the channel in bulk.
@@ -321,13 +322,13 @@ class PartialChannel:
         )
         ids = [msg.id for msg in messages]
         if len(ids) < 2:
-            await self.client.http.delete_message(self.id, ids[0])
+            await self.client.http.delete_message(self.id, ids[0], reason=reason)
             return messages
-        await self.client.http.bulk_delete_messages(self.id, {"messages": ids})
+        await self.client.http.bulk_delete_messages(self.id, {"messages": ids}, reason=reason)
         return messages
 
-    async def delete(self):
-        await self.client.http.delete_or_close_channel(self.id)
+    async def delete(self, *, reason: Optional[str] = None):
+        await self.client.http.delete_or_close_channel(self.id, reason=reason)
 
     async def crosspost(self, message_id: str):
         resp = await self.client.http.crosspost_channel_message(self.id, message_id)

--- a/discohook/channel.py
+++ b/discohook/channel.py
@@ -321,7 +321,7 @@ class PartialChannel:
         )
         ids = [msg.id for msg in messages]
         if len(ids) < 2:
-            await self.client.http.delete_channel_message(self.id, ids[0])
+            await self.client.http.delete_message(self.id, ids[0])
             return messages
         await self.client.http.delete_channel_messages(self.id, {"messages": ids})
         return messages

--- a/discohook/channel.py
+++ b/discohook/channel.py
@@ -247,7 +247,7 @@ class PartialChannel:
         :class:`Message`
             The fetched message.
         """
-        resp = await self.client.http.fetch_channel_message(self.id, message_id)
+        resp = await self.client.http.get_channel_message(self.id, message_id)
         data = await resp.json()
         return Message(self.client, data)
 

--- a/discohook/channel.py
+++ b/discohook/channel.py
@@ -323,7 +323,7 @@ class PartialChannel:
         if len(ids) < 2:
             await self.client.http.delete_message(self.id, ids[0])
             return messages
-        await self.client.http.delete_channel_messages(self.id, {"messages": ids})
+        await self.client.http.bulk_delete_messages(self.id, {"messages": ids})
         return messages
 
     async def delete(self):

--- a/discohook/channel.py
+++ b/discohook/channel.py
@@ -229,7 +229,7 @@ class PartialChannel:
             payload["default_sort_order"] = default_sort_order
         if default_forum_layout:
             payload["default_forum_layout"] = default_forum_layout
-        resp = await self.client.http.edit_channel(self.id, payload)
+        resp = await self.client.http.modify_channel(self.id, payload)
         data = await resp.json()
         return Channel(self.client, data)
 

--- a/discohook/client.py
+++ b/discohook/client.py
@@ -374,7 +374,7 @@ class Client(Starlette):
         if self._sync_queue:
             responses.append(
                 (
-                    await self.http.sync_global_commands(
+                    await self.http.bulk_overwrite_global_application_commands(
                         str(self.application_id),
                         [cmd.to_dict() for cmd in self._sync_queue],
                     )

--- a/discohook/client.py
+++ b/discohook/client.py
@@ -363,7 +363,7 @@ class Client(Starlette):
             tasks = []
             for guild_id, commands in guild_commands.items():
                 tasks.append(
-                    self.http.sync_guild_commands(
+                    self.http.bulk_overwrite_guild_application_commands(
                         str(self.application_id),
                         guild_id,
                         [cmd.to_dict() for cmd in commands],

--- a/discohook/client.py
+++ b/discohook/client.py
@@ -383,7 +383,12 @@ class Client(Starlette):
         return responses, [cmd.to_dict() for cmd in self._sync_queue]
 
     async def create_webhook(
-        self, channel_id: str, *, name: str, image_base64: Optional[str] = None
+        self, 
+        channel_id: str, 
+        *, 
+        name: str, 
+        image_base64: Optional[str] = None,
+        reason: Optional[str] = None
     ):
         """
         Create a webhook in a channel.
@@ -402,7 +407,7 @@ class Client(Starlette):
 
         """
         resp = await self.http.create_webhook(
-            channel_id, {"name": name, "avatar": image_base64}
+            channel_id, {"name": name, "avatar": image_base64}, reason=reason
         )
         data = await resp.json()
         return Webhook(self, data)

--- a/discohook/client.py
+++ b/discohook/client.py
@@ -489,7 +489,7 @@ class Client(Starlette):
         -------
         Dict[str, Any]
         """
-        resp = await self.http.fetch_application()
+        resp = await self.http.get_current_application()
         return await resp.json()
 
     async def fetch_application_emojis(self):

--- a/discohook/client.py
+++ b/discohook/client.py
@@ -346,7 +346,7 @@ class Client(Starlette):
         payload = {"username": username}
         if avatar:
             payload["avatar"] = avatar
-        await self.http.edit_client(payload)
+        await self.http.modify_current_user(payload)
 
     async def _sync(self) -> Tuple[List[aiohttp.ClientResponse], List[Dict[str, Any]]]:
         """

--- a/discohook/client.py
+++ b/discohook/client.py
@@ -329,7 +329,7 @@ class Client(Starlette):
         User
             The client as a user.
         """
-        resp = await self.http.fetch_user(self.application_id)
+        resp = await self.http.get_user(self.application_id)
         return User(self, await resp.json())
 
     async def edit(self, username: str, *, avatar: Optional[str] = None):
@@ -448,7 +448,7 @@ class Client(Starlette):
         -------
         User
         """
-        resp = await self.http.fetch_user(user_id)
+        resp = await self.http.get_user(user_id)
         data = await resp.json()
         if not data.get("id"):
             return None

--- a/discohook/client.py
+++ b/discohook/client.py
@@ -462,7 +462,7 @@ class Client(Starlette):
         -------
         Channel
         """
-        resp = await self.http.fetch_channel(channel_id)
+        resp = await self.http.get_channel(channel_id)
         data = await resp.json()
         if not data.get("id"):
             return None

--- a/discohook/client.py
+++ b/discohook/client.py
@@ -476,7 +476,7 @@ class Client(Starlette):
         -------
         List[Dict[str, Any]]
         """
-        resp = await self.http.fetch_global_application_commands(
+        resp = await self.http.get_global_application_commands(
             str(self.application_id)
         )
         return await resp.json()

--- a/discohook/client.py
+++ b/discohook/client.py
@@ -501,7 +501,7 @@ class Client(Starlette):
         """
         Fetch all emojis from the client.
         """
-        resp = await self.http.fetch_application_emojis()
+        resp = await self.http.list_application_emojis()
         return await resp.json()
 
     async def fetch_application_emoji(self, emoji_id: str):
@@ -513,7 +513,7 @@ class Client(Starlette):
         emoji_id: str
             The ID of the emoji to fetch.
         """
-        resp = await self.http.fetch_application_emoji(emoji_id)
+        resp = await self.http.get_application_emoji(emoji_id)
         return await resp.json()
 
     async def create_application_emoji(self, name: str, image_base64: str):
@@ -540,7 +540,7 @@ class Client(Starlette):
         name: str
             The name of the emoji.
         """
-        await self.http.edit_application_emoji(emoji_id, {"name": name})
+        await self.http.modify_application_emoji(emoji_id, name)
 
     async def delete_application_emoji(self, emoji_id: str):
         """

--- a/discohook/guild.py
+++ b/discohook/guild.py
@@ -48,7 +48,7 @@ class PartialGuild:
         -------
         List[Channel]
         """
-        resp = await self.client.http.fetch_guild_channels(self.id)
+        resp = await self.client.http.get_guild_channels(self.id)
         data = await resp.json()
         return [Channel(self.client, c) for c in data]
 

--- a/discohook/guild.py
+++ b/discohook/guild.py
@@ -228,7 +228,12 @@ class PartialGuild:
         return Role(self.client, data)
 
     async def create_emoji(
-        self, name: str, image: str, *, roles: Optional[List[str]] = None
+        self, 
+        name: str, 
+        image: str, 
+        *, 
+        roles: Optional[List[str]] = None,
+        reason: Optional[str] = None
     ):
         """
         Creates a new emoji for the guild.
@@ -249,7 +254,7 @@ class PartialGuild:
         payload = {"name": name, "image": image}
         if roles:
             payload["roles"] = roles
-        resp = await self.client.http.create_guild_emoji(self.id, payload)
+        resp = await self.client.http.create_guild_emoji(self.id, payload, reason=reason)
         return await resp.json()
 
 

--- a/discohook/guild.py
+++ b/discohook/guild.py
@@ -84,6 +84,7 @@ class PartialGuild:
         default_reaction_emoji: Optional[PartialEmoji] = None,
         available_tags: Optional[List[Dict[str, Any]]] = None,
         default_sort_order: Optional[int] = None,
+        reason: Optional[str] = None
     ) -> Channel:
         """
         Creates a channel in the guild. Requires the MANAGE_CHANNELS permission.
@@ -158,7 +159,7 @@ class PartialGuild:
             payload["available_tags"] = available_tags
         if default_sort_order:
             payload["default_sort_order"] = default_sort_order
-        resp = await self.client.http.create_guild_channel(self.id, payload)
+        resp = await self.client.http.create_guild_channel(self.id, payload, reason=reason)
         data = await resp.json()
         return Channel(self.client, data)
 

--- a/discohook/guild.py
+++ b/discohook/guild.py
@@ -60,7 +60,7 @@ class PartialGuild:
         -------
         List[Role]
         """
-        resp = await self.client.http.fetch_guild_roles(self.id)
+        resp = await self.client.http.get_guild_roles(self.id)
         data = await resp.json()
         return [Role(self.client, r) for r in data]
 

--- a/discohook/guild.py
+++ b/discohook/guild.py
@@ -34,7 +34,7 @@ class PartialGuild:
         -------
         Optional[:class:`Member`]
         """
-        resp = await self.client.http.fetch_guild_member(self.id, user_id)
+        resp = await self.client.http.get_guild_member(self.id, user_id)
         data = await resp.json()
         if not data.get("user"):
             return

--- a/discohook/guild.py
+++ b/discohook/guild.py
@@ -193,7 +193,7 @@ class PartialGuild:
         }
         if parent_id:
             payload["parent_id"] = parent_id
-        await self.client.http.edit_guild_channel_position(self.id, payload)
+        await self.client.http.modify_guild_channel_positions(self.id, payload)
 
     async def create_role(
         self,

--- a/discohook/guild.py
+++ b/discohook/guild.py
@@ -205,6 +205,7 @@ class PartialGuild:
         mentionable: Optional[bool] = False,
         icon_data_uri: Optional[str] = None,
         unicode_emoji: Optional[str] = None,
+        reason: Optional[str] = None
     ):
         payload = {"name": name}
         base_permissions = 0
@@ -222,7 +223,7 @@ class PartialGuild:
             payload["icon"] = icon_data_uri
         if unicode_emoji:
             payload["unicode_emoji"] = unicode_emoji
-        resp = await self.client.http.create_guild_role(self.id, payload)
+        resp = await self.client.http.create_guild_role(self.id, payload, reason=reason)
         data = await resp.json()
         return Role(self.client, data)
 

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -413,7 +413,21 @@ class HTTPClient:
             reason=reason
         )
 
-    async def modify_guild_role_positions(): pass
+    async def modify_guild_role_positions(
+        self, 
+        guild_id: str, 
+        payload: Dict[str, Any],
+        *,
+        reason: Optional[str] = None
+    ):
+        return await self.request(
+            "PATCH", 
+            f"/guilds/{guild_id}/roles", 
+            body=payload, 
+            authorize=True,
+            reason=reason
+        )
+
     async def modify_guild_role(): pass
     async def modify_guild_mfa_level(): pass
     async def delete_guild_role(): pass
@@ -705,10 +719,6 @@ class HTTPClient:
     # end todo
 
 
-    async def edit_guild_role_position(self, guild_id: str, payload: Dict[str, Any]):
-        return await self.request(
-            "PATCH", f"/guilds/{guild_id}/roles", body=payload, authorize=True
-        )
 
     async def edit_guild_role(
         self, guild_id: str, role_id: str, payload: Dict[str, Any]

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -656,7 +656,21 @@ class HTTPClient:
     # Webhook Resource
     # https://discord.com/developers/docs/resources/webhook#webhook-resource
 
-    async def create_webhook(): pass
+    async def create_webhook(
+        self, 
+        channel_id: str, 
+        payload: Dict[str, Any],
+        *,
+        reason: Optional[str] = None
+    ):
+        return await self.request(
+            "POST", 
+            f"/channels/{channel_id}/webhooks", 
+            body=payload, 
+            authorize=True,
+            reason=reason
+        )
+
     async def get_channel_webhooks(): pass
     async def get_guild_webhooks(): pass
     async def get_webhook(): pass
@@ -747,11 +761,6 @@ class HTTPClient:
         )
 
     # end todo
-
-    async def create_webhook(self, channel_id: str, payload: Dict[str, Any]):
-        return await self.request(
-            "POST", f"/channels/{channel_id}/webhooks", body=payload, authorize=True
-        )
 
     async def execute_webhook(
         self,

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -351,7 +351,14 @@ class HTTPClient:
     async def get_reactions(): pass
     async def delete_all_reactions(): pass
     async def delete_all_reactions_for_emoji(): pass
-    async def edit_message(): pass
+
+    async def edit_message(elf, channel_id: str, message_id: str, data: Any):
+        return await self.request(
+            "PATCH",
+            f"/channels/{channel_id}/messages/{message_id}",
+            body=data,
+            authorize=True,
+        )
 
     async def delete_message(self, channel_id: str, message_id: str, reason: Optional[str] = None):
         await self.request(
@@ -497,14 +504,6 @@ class HTTPClient:
     async def fetch_channel_messages(self, channel_id: str, params: Dict[str, Any]):
         return await self.request(
             "GET", f"/channels/{channel_id}/messages", params=params, authorize=True
-        )
-
-    async def edit_channel_message(self, channel_id: str, message_id: str, data: Any):
-        return await self.request(
-            "PATCH",
-            f"/channels/{channel_id}/messages/{message_id}",
-            body=data,
-            authorize=True,
         )
 
     async def send_webhook_message(

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -60,6 +60,298 @@ class HTTPClient:
             raise HTTPException(resp, await resp.read())
         return resp
 
+    # Interactions
+    # https://discord.com/developers/docs/interactions/receiving-and-responding#interactions
+
+    async def create_interaction_response(): pass
+    async def get_original_interaction_response(): pass # get_webhook_message(), message_id as @original
+    async def edit_original_interaction_response(): pass # edit_webhook_message(), message_id as @original
+    async def delete_original_interaction_response(): pass # delete_webhook_message(), message_id as @original + no thread_id param
+    async def create_followup_message(): pass # execute_webhook()
+    async def get_followup_message(): pass # get_webhook_message()
+    async def edit_followup_message(): pass # edit_webhook_message()
+    async def delete_followup_message(): pass # delete_webhook_message()
+
+    # Application Role Connection Metadata
+    # https://discord.com/developers/docs/resources/application-role-connection-metadata#application-role-connection-metadata
+
+    async def get_application_role_connection_metadata_records(): pass
+    async def update_application_role_connection_metadata_records(): pass
+
+    # Application Resource
+    # https://discord.com/developers/docs/resources/application#application-resource
+
+    async def get_current_application(): pass
+    async def edit_current_application(): pass
+    async def get_application_activity_instance(): pass
+
+    # Audit Logs Resource
+    # https://discord.com/developers/docs/resources/audit-log#audit-logs-resource
+
+    async def get_audit_log(): pass
+
+    # Auto Moderation
+    # https://discord.com/developers/docs/resources/auto-moderation#auto-moderation
+
+    async def list_auto_moderation_rules_for_guild(): pass
+    async def get_auto_moderation_rule(): pass
+    async def create_auto_moderation_rule(): pass
+    async def modify_auto_moderation_rule(): pass
+    async def delete_auto_moderation_rule(): pass
+
+    # Channels Resource
+    # https://discord.com/developers/docs/resources/channel#channels-resource
+
+    async def get_channel(): pass
+    async def modify_channel(): pass
+    async def delete_or_close_channel(): pass # "closes" a dm channel
+    async def edit_channel_permissions(): pass
+    async def get_channel_invites(): pass
+    async def create_channel_invite(): pass
+    async def delete_channel_permission(): pass
+    async def follow_announcement_channel(): pass
+    async def trigger_typing_indicator(): pass
+    async def get_pinned_messages(): pass
+    async def pin_message(): pass
+    async def unpin_message(): pass
+    async def group_dm_add_recipient(): pass
+    async def group_dm_remove_recipient(): pass
+    async def start_thread_from_message(): pass
+    async def start_thread_without_message(): pass
+    async def start_thread_in_forum_or_media_channel(): pass
+    async def join_thread(): pass
+    async def add_thread_member(): pass
+    async def leave_thread(): pass
+    async def remove_thread_member(): pass
+    async def get_thread_member(): pass
+    async def list_thread_member(): pass
+    async def list_public_archived_threads(): pass
+    async def list_private_archived_threads(): pass
+    async def list_joined_private_threads(): pass
+    
+    # Emoji Resource
+    # https://discord.com/developers/docs/resources/emoji#emoji-resource
+
+    async def list_guild_emojis(): pass
+    async def get_guild_emoji(): pass
+    async def create_guild_emoji(): pass
+    async def modify_guild_emoji(): pass
+    async def delete_guild_emoji(): pass
+    async def list_application_emojis(): pass
+    async def get_application_emoji(): pass
+    async def create_application_emoji(): pass
+    async def modify_application_emoji(): pass
+    
+    # Entitlements Resource
+    # https://discord.com/developers/docs/resources/entitlement#entitlements-resource
+
+    async def list_entitlements(): pass
+    async def get_entitlement(): pass
+    async def consume_entitlement(): pass
+    async def create_test_entitlement(): pass
+    async def delete_test_entitlement(): pass
+
+    # Guild Scheduled Event
+    # https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event
+
+    async def list_scheduled_events_for_guild(): pass
+    async def create_guild_scheduled_event(): pass
+    async def get_guild_scheduled_event(): pass
+    async def modify_guild_scheduled_event(): pass
+    async def delete_guild_scheduled_event(): pass
+    async def get_guild_scheduled_event_users(): pass
+
+    # Guild Template Resource
+    # https://discord.com/developers/docs/resources/guild-template#guild-template-resource
+
+    async def get_guild_template(): pass
+    async def create_guild_from_guild_template(): pass
+    async def get_guild_templates(): pass
+    async def create_guild_template(): pass
+    async def sync_guild_template(): pass
+    async def modify_guild_template(): pass
+    async def delete_guild_template(): pass
+
+    # Guild Resource
+    # https://discord.com/developers/docs/resources/guild#guild-resource
+
+    async def create_guild(): pass
+    async def get_guild(): pass
+    async def get_guild_preview(): pass
+    async def modify_guild(): pass
+    async def delete_guild(): pass
+    async def get_guild_channels(): pass
+    async def create_guild_channel(): pass
+    async def modify_guild_channel_positions(): pass
+    async def list_active_guild_threads(): pass
+    async def get_guild_member(): pass
+    async def list_guild_members(): pass
+    async def search_guild_members(): pass
+    async def add_guild_member(): pass
+    async def modify_guild_member(): pass
+    async def modify_current_member(): pass
+    async def modify_current_user_nick(): pass
+    async def add_guild_member_role(): pass
+    async def remove_guild_member_role(): pass
+    async def remove_guild_member(): pass
+    async def get_guild_bans(): pass
+    async def get_guild_ban(): pass
+    async def create_guild_ban(): pass
+    async def remove_guild_ban(): pass
+    async def bulk_guild_ban(): pass
+    async def get_guild_roles(): pass
+    async def get_guild_role(): pass
+    async def create_guild_role(): pass
+    async def modify_guild_role_positions(): pass
+    async def modify_guild_role(): pass
+    async def modify_guild_mfa_level(): pass
+    async def delete_guild_role(): pass
+    async def get_guild_prune_count(): pass
+    async def begin_guild_prune(): pass
+    async def get_guild_voice_regions(): pass
+    async def get_guild_invites(): pass
+    async def get_guild_integrations(): pass
+    async def delete_guild_integration(): pass
+    async def get_guild_widget_settings(): pass
+    async def modify_guild_widget(): pass
+    async def get_guild_widget(): pass
+    async def get_guild_vanity_url(): pass
+    async def get_guild_widget_image(): pass
+    async def get_guild_welcome_screen(): pass
+    async def modify_guild_welcome_screen(): pass
+    async def get_guild_onboarding(): pass
+    async def modify_guild_onboarding(): pass
+    async def modify_guild_incident_actions(): pass
+
+    # Invite Resource
+    # https://discord.com/developers/docs/resources/invite#invite-resource
+
+    async def get_invite(): pass
+    async def delete_invite(): pass
+
+    # Lobby Resource
+    # https://discord.com/developers/docs/resources/lobby#lobby-resource
+
+    async def create_lobby(): pass
+    async def get_lobby(): pass
+    async def modify_lobby(): pass
+    async def delete_lobby(): pass
+    async def add_a_member_to_a_lobby(): pass
+    async def remove_a_member_from_a_lobby(): pass
+    async def leave_lobby(): pass
+    async def link_channel_to_lobby(): pass
+    async def unlink_channel_from_lobby(): pass
+
+    # Messages Resource
+    # https://discord.com/developers/docs/resources/channel#message-resource
+
+    async def get_channel_messages(): pass
+    async def get_channel_message(): pass
+    async def create_message(): pass
+    async def crosspost_message(): pass
+    async def create_reaction(): pass
+    async def delete_own_reaction(): pass
+    async def delete_user_reaction(): pass
+    async def get_reactions(): pass
+    async def delete_all_reactions(): pass
+    async def delete_all_reactions_for_emoji(): pass
+    async def edit_message(): pass
+    async def delete_message(): pass
+    async def bulk_delete_messages(): pass
+
+    # Poll Resource
+    # https://discord.com/developers/docs/resources/poll#poll-resource
+
+    async def get_answer_voters(): pass
+    async def end_poll(): pass
+
+    # SKU Resource
+    # https://discord.com/developers/docs/resources/sku#sku-resource
+
+    async def list_skus(): pass
+
+    # Soundboard Resource
+    # https://discord.com/developers/docs/resources/soundboard#soundboard-resource
+
+    async def send_soundboard_sound(): pass
+    async def list_default_soundboard_sounds(): pass
+    async def list_guild_soundboard_sounds(): pass
+    async def get_guild_soundboard_sound(): pass
+    async def create_guild_soundboard_sound(): pass
+    async def modify_guild_soundboard_sound(): pass
+    async def delete_guild_soundboard_sound(): pass
+
+    # Stage Instance Resource
+    # https://discord.com/developers/docs/resources/stage-instance#stage-instance-resource
+
+    async def create_stage_instance(): pass
+    async def get_stage_instance(): pass
+    async def modify_stage_instance(): pass
+    async def delete_stage_instance(): pass
+
+    # Sticker Resource
+    # https://discord.com/developers/docs/resources/sticker#sticker-resource
+
+    async def get_sticker(): pass
+    async def list_sticker_packs(): pass
+    async def get_sticker_pack(): pass
+    async def list_guild_stickers(): pass
+    async def get_guild_sticker(): pass
+    async def create_guild_sticker(): pass
+    async def modify_guild_sticker(): pass
+    async def delete_guild_sticker(): pass
+
+    # Subscription Resource
+    # https://discord.com/developers/docs/resources/subscription#subscription-resource
+
+    async def list_sku_subscriptions(): pass
+    async def get_sku_subscription(): pass
+
+    # Users Resource
+    # https://discord.com/developers/docs/resources/user#user-resource
+
+    async def get_current_user(): pass
+    async def get_user(): pass
+    async def modify_current_user(): pass
+    async def get_current_user_guilds(): pass
+    async def get_current_user_guild_member(): pass
+    async def leave_guild(): pass
+    async def create_dm(): pass
+    async def create_group_dm(): pass
+    async def get_current_user_connections(): pass
+    async def get_current_user_application_role_connection(): pass
+    async def update_current_user_application_role_connection(): pass
+
+    # Voice Resource
+    # https://discord.com/developers/docs/resources/voice#voice-resource
+
+    async def list_voice_regions(): pass
+    async def get_current_user_voice_state(): pass
+    async def get_user_voice_state(): pass
+    async def modify_current_user_voice_state(): pass
+    async def modify_user_voice_state(): pass
+
+    # Webhook Resource
+    # https://discord.com/developers/docs/resources/webhook#webhook-resource
+
+    async def create_webhook(): pass
+    async def get_channel_webhooks(): pass
+    async def get_guild_webhooks(): pass
+    async def get_webhook(): pass
+    async def get_webhook_with_token(): pass
+    async def modify_webhook(): pass
+    async def modify_webhook_with_token(): pass
+    async def delete_webhook(): pass
+    async def delete_webhook_with_token(): pass
+    async def execute_webhook(): pass
+    async def execute_slack_compatible_webhook(): pass
+    async def execute_github_compatible_webhook(): pass
+    async def get_webhook_message(): pass
+    async def edit_webhook_message(): pass
+    async def delete_webhook_message(): pass
+
+    # todo
+
     async def fetch_application(self):
         return await self.request("GET", "/applications/@me", authorize=True)
 

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -346,7 +346,19 @@ class HTTPClient:
             reason=reason
         )
 
-    async def bulk_delete_messages(): pass
+    async def bulk_delete_messages(
+        self, 
+        channel_id: str, 
+        payload: Dict[str, Any], 
+        reason: Optional[str] = None
+    ):
+        await self.request(
+            "POST",
+            f"/channels/{channel_id}/messages/bulk-delete",
+            body=payload,
+            authorize=True,
+            reason=reason
+        )
 
     # Poll Resource
     # https://discord.com/developers/docs/resources/poll#poll-resource
@@ -470,14 +482,6 @@ class HTTPClient:
     async def fetch_channel_messages(self, channel_id: str, params: Dict[str, Any]):
         return await self.request(
             "GET", f"/channels/{channel_id}/messages", params=params, authorize=True
-        )
-
-    async def delete_channel_messages(self, channel_id: str, payload: Dict[str, Any]):
-        await self.request(
-            "POST",
-            f"/channels/{channel_id}/messages/bulk-delete",
-            body=payload,
-            authorize=True,
         )
 
     async def pin_channel_message(self, channel_id: str, message_id: str):

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -361,7 +361,10 @@ class HTTPClient:
 
     async def get_current_user(): pass
     async def get_user(): pass
-    async def modify_current_user(): pass
+    
+    async def modify_current_user(self, payload: Dict[str, Any]):
+        return await self.request("PATCH", "/users/@me", body=payload, authorize=True)
+
     async def get_current_user_guilds(): pass
     async def get_current_user_guild_member(): pass
     async def leave_guild(): pass
@@ -400,9 +403,6 @@ class HTTPClient:
     async def delete_webhook_message(): pass
 
     # todo
-
-    async def edit_client(self, payload: Dict[str, Any]):
-        return await self.request("PATCH", "/users/@me", body=payload, authorize=True)
 
     async def delete_command(
         self, application_id: str, command_id: str, guild_id: Optional[str] = None

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -354,7 +354,10 @@ class HTTPClient:
 
     async def remove_guild_ban(): pass
     async def bulk_guild_ban(): pass
-    async def get_guild_roles(): pass
+
+    async def get_guild_roles(self, guild_id: str):
+        return await self.request("GET", f"/guilds/{guild_id}/roles", authorize=True)
+
     async def get_guild_role(): pass
     async def create_guild_role(): pass
     async def modify_guild_role_positions(): pass
@@ -641,9 +644,6 @@ class HTTPClient:
         )
 
     # end todo
-
-    async def fetch_guild_roles(self, guild_id: str):
-        return await self.request("GET", f"/guilds/{guild_id}/roles", authorize=True)
 
     async def create_guild_channel(self, guild_id: str, payload: Dict[str, Any]):
         return await self.request(

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -262,10 +262,32 @@ class HTTPClient:
     # https://discord.com/developers/docs/resources/entitlement#entitlements-resource
 
     async def list_entitlements(): pass
-    async def get_entitlement(): pass
-    async def consume_entitlement(): pass
-    async def create_test_entitlement(): pass
-    async def delete_test_entitlement(): pass
+
+    async def get_entitlement(self, application_id: str, entitlement_id: str):
+        return await self.request(
+            "GET",
+            f"/applications/{application_id}/entitlements/{entitlement_id}",
+            authorize=True,
+        )
+
+    async def consume_entitlement(): pass    
+    
+    async def create_test_entitlement(
+        self, application_id: str, payload: Dict[str, Any]
+    ):
+        return await self.request(
+            "POST",
+            f"/applications/{application_id}/entitlements",
+            body=payload,
+            authorize=True,
+        )
+
+    async def delete_test_entitlement(self, application_id: str, entitlement_id: str):
+        return await self.request(
+            "DELETE",
+            f"/applications/{application_id}/entitlements/{entitlement_id}",
+            authorize=True,
+        )
 
     # Guild Scheduled Event
     # https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event
@@ -585,7 +607,10 @@ class HTTPClient:
     # SKU Resource
     # https://discord.com/developers/docs/resources/sku#sku-resource
 
-    async def list_skus(): pass
+    async def list_skus(self, application_id: str):
+        return await self.request(
+            "GET", f"/applications/{application_id}/skus", authorize=True
+        )
 
     # Soundboard Resource
     # https://discord.com/developers/docs/resources/soundboard#soundboard-resource
@@ -807,8 +832,6 @@ class HTTPClient:
             return await self.request("GET", f"/webhooks/{webhook_id}/{webhook_token}")
         return await self.request("GET", f"/webhooks/{webhook_id}", authorize=True)
 
-    # end todo
-    
     async def delete_message_reaction(self, message_id: str, emoji: str, user_id: str):
         return await self.request(
             "DELETE",
@@ -824,30 +847,6 @@ class HTTPClient:
             path += f"/{emoji}"
         return await self.request("DELETE", path, authorize=True)
 
-    async def create_test_entitlement(
-        self, application_id: str, payload: Dict[str, Any]
-    ):
-        return await self.request(
-            "POST",
-            f"/applications/{application_id}/entitlements",
-            body=payload,
-            authorize=True,
-        )
-
-    async def delete_test_entitlement(self, application_id: str, entitlement_id: str):
-        return await self.request(
-            "DELETE",
-            f"/applications/{application_id}/entitlements/{entitlement_id}",
-            authorize=True,
-        )
-
-    async def fetch_entitlement(self, application_id: str, entitlement_id: str):
-        return await self.request(
-            "GET",
-            f"/applications/{application_id}/entitlements/{entitlement_id}",
-            authorize=True,
-        )
-
     async def fetch_entitlements(self, application_id: str, params: Dict[str, Any]):
         return await self.request(
             "GET",
@@ -856,10 +855,7 @@ class HTTPClient:
             authorize=True,
         )
 
-    async def fetch_skus(self, application_id: str):
-        return await self.request(
-            "GET", f"/applications/{application_id}/skus", authorize=True
-        )
+    # end todo
 
     async def start_thread_without_message(
         self, channel_id: str, payload: Dict[str, Any], reason: Optional[str] = None

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -475,7 +475,9 @@ class HTTPClient:
     # https://discord.com/developers/docs/resources/user#user-resource
 
     async def get_current_user(): pass
-    async def get_user(): pass
+
+    async def get_user(self, user_id: str):
+        return await self.request("GET", f"/users/{user_id}", authorize=True)
     
     async def modify_current_user(self, payload: Dict[str, Any]):
         return await self.request("PATCH", "/users/@me", body=payload, authorize=True)
@@ -586,9 +588,6 @@ class HTTPClient:
         )
         
     # end todo
-
-    async def fetch_user(self, user_id: str):
-        return await self.request("GET", f"/users/{user_id}", authorize=True)
 
     async def kick_user(self, guild_id: str, user_id: str):
         return await self.request(

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -81,7 +81,9 @@ class HTTPClient:
     # Application Resource
     # https://discord.com/developers/docs/resources/application#application-resource
 
-    async def get_current_application(): pass
+    async def get_current_application(self):
+        return await self.request("GET", "/applications/@me", authorize=True)
+
     async def edit_current_application(): pass
     async def get_application_activity_instance(): pass
 
@@ -351,9 +353,6 @@ class HTTPClient:
     async def delete_webhook_message(): pass
 
     # todo
-
-    async def fetch_application(self):
-        return await self.request("GET", "/applications/@me", authorize=True)
 
     async def sync_global_commands(
         self, application_id: str, commands: List[Dict[str, Any]]

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -217,7 +217,22 @@ class HTTPClient:
 
     async def group_dm_add_recipient(): pass
     async def group_dm_remove_recipient(): pass
-    async def start_thread_from_message(): pass
+
+    async def start_thread_from_message(
+        self,
+        channel_id: str,
+        message_id: str,
+        payload: Dict[str, Any],
+        *,
+        reason: Optional[str] = None,
+    ):
+        return await self.request(
+            "POST",
+            f"/channels/{channel_id}/messages/{message_id}/threads",
+            body=payload,
+            authorize=True,
+            reason=reason
+        )
 
     async def start_thread_without_message(
         self, 
@@ -871,21 +886,6 @@ class HTTPClient:
         )
 
     # end todo
-
-    async def start_thread_with_message(
-        self,
-        channel_id: str,
-        message_id: str,
-        payload: Dict[str, Any],
-        reason: Optional[str] = None,
-    ):
-        return await self.request(
-            "POST",
-            f"/channels/{channel_id}/messages/{message_id}/threads",
-            body=payload,
-            reason=reason,
-            authorize=True
-        )
 
     async def fetch_answer_voters(
         self,

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -309,7 +309,20 @@ class HTTPClient:
             authorize=True,
         )
 
-    async def remove_guild_member(): pass
+    async def remove_guild_member(
+        self, 
+        guild_id: str, 
+        user_id: str, 
+        *, 
+        reason: Optional[str] = None
+    ):
+        return await self.request(
+            "DELETE", 
+            f"/guilds/{guild_id}/members/{user_id}", 
+            authorize=True,
+            reason=reason
+        )
+
     async def get_guild_bans(): pass
     async def get_guild_ban(): pass
     async def create_guild_ban(): pass
@@ -588,11 +601,6 @@ class HTTPClient:
         )
         
     # end todo
-
-    async def kick_user(self, guild_id: str, user_id: str):
-        return await self.request(
-            "DELETE", f"/guilds/{guild_id}/members/{user_id}", authorize=True
-        )
 
     async def ban_user(
         self, guild_id: str, user_id: str, delete_message_seconds: int = 0

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -74,13 +74,25 @@ class HTTPClient:
 
     # Application Commands
     # https://discord.com/developers/docs/interactions/application-commands#application-commands
-    
+
     async def get_global_application_commands(): pass
     async def create_global_application_command(): pass
     async def get_global_application_command(): pass
     async def edit_global_application_command(): pass
     async def delete_global_application_command(): pass
-    async def bulk_overwrite_global_application_commands(): pass
+
+    async def bulk_overwrite_global_application_commands(
+        self, 
+        application_id: str, 
+        commands: List[Dict[str, Any]]
+    ):
+        return await self.request(
+            "PUT",
+            f"/applications/{application_id}/commands",
+            body=commands,
+            authorize=True,
+        )
+
     async def get_guild_application_commands(): pass
     async def create_guild_application_command(): pass
     async def get_guild_application_command(): pass
@@ -372,16 +384,6 @@ class HTTPClient:
     async def delete_webhook_message(): pass
 
     # todo
-
-    async def sync_global_commands(
-        self, application_id: str, commands: List[Dict[str, Any]]
-    ):
-        return await self.request(
-            "PUT",
-            f"/applications/{application_id}/commands",
-            body=commands,
-            authorize=True,
-        )
 
     async def sync_guild_commands(
         self, application_id: str, guild_id: str, commands: List[Dict[str, Any]]

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -75,19 +75,7 @@ class HTTPClient:
     # Application Commands
     # https://discord.com/developers/docs/interactions/application-commands#application-commands
 
-    async def get_global_application_commands(
-        self, 
-        application_id: str,
-        *,
-        with_localizations: bool = False
-    ):
-        return await self.request(
-            "GET", 
-            f"/applications/{application_id}/commands", 
-            authorize=True,
-            with_localizations=with_localizations
-        )
-    
+    async def get_global_application_commands(): pass
     async def create_global_application_command(): pass
     async def get_global_application_command(): pass
     async def edit_global_application_command(): pass
@@ -486,6 +474,19 @@ class HTTPClient:
     async def delete_webhook_message(): pass
 
     # todo
+
+    async def get_global_application_commands(
+        self, 
+        application_id: str,
+        *,
+        with_localizations: bool = False
+    ):
+        return await self.request(
+            "GET", 
+            f"/applications/{application_id}/commands", 
+            authorize=True,
+            with_localizations=with_localizations
+        )
 
     async def delete_command(
         self, application_id: str, command_id: str, guild_id: Optional[str] = None

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -313,7 +313,13 @@ class HTTPClient:
     # https://discord.com/developers/docs/resources/channel#message-resource
 
     async def get_channel_messages(): pass
-    async def get_channel_message(): pass
+
+    async def get_channel_message(self, channel_id: str, message_id: str):
+        return await self.request(
+            "GET", 
+            f"/channels/{channel_id}/messages/{message_id}", 
+            authorize=True
+        )
 
     async def create_message(self, channel_id: str, data: Any):
         return await self.request(
@@ -451,11 +457,6 @@ class HTTPClient:
             "DELETE",
             f"/applications/{application_id}/commands/{command_id}",
             authorize=True,
-        )
-
-    async def fetch_channel_message(self, channel_id: str, message_id: str):
-        return await self.request(
-            "GET", f"/channels/{channel_id}/messages/{message_id}", authorize=True
         )
 
     async def fetch_channel_messages(self, channel_id: str, params: Dict[str, Any]):

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -72,6 +72,25 @@ class HTTPClient:
     async def edit_followup_message(): pass # edit_webhook_message()
     async def delete_followup_message(): pass # delete_webhook_message()
 
+    # Application Commands
+    # https://discord.com/developers/docs/interactions/application-commands#application-commands
+    
+    async def get_global_application_commands(): pass
+    async def create_global_application_command(): pass
+    async def get_global_application_command(): pass
+    async def edit_global_application_command(): pass
+    async def delete_global_application_command(): pass
+    async def bulk_overwrite_global_application_commands(): pass
+    async def get_guild_application_commands(): pass
+    async def create_guild_application_command(): pass
+    async def get_guild_application_command(): pass
+    async def edit_guild_application_command(): pass
+    async def delete_guild_application_command(): pass
+    async def bulk_overwrite_guild_application_commands(): pass
+    async def get_guild_application_command_permissions(): pass
+    async def get_application_command_permissions(): pass
+    async def edit_application_command_permissions(): pass
+
     # Application Role Connection Metadata
     # https://discord.com/developers/docs/resources/application-role-connection-metadata#application-role-connection-metadata
 

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -98,7 +98,17 @@ class HTTPClient:
     async def get_guild_application_command(): pass
     async def edit_guild_application_command(): pass
     async def delete_guild_application_command(): pass
-    async def bulk_overwrite_guild_application_commands(): pass
+
+    async def bulk_overwrite_guild_application_commands(
+        self, application_id: str, guild_id: str, commands: List[Dict[str, Any]]
+    ):
+        return await self.request(
+            "PUT",
+            f"/applications/{application_id}/guilds/{guild_id}/commands",
+            body=commands,
+            authorize=True,
+        )
+
     async def get_guild_application_command_permissions(): pass
     async def get_application_command_permissions(): pass
     async def edit_application_command_permissions(): pass
@@ -385,15 +395,6 @@ class HTTPClient:
 
     # todo
 
-    async def sync_guild_commands(
-        self, application_id: str, guild_id: str, commands: List[Dict[str, Any]]
-    ):
-        return await self.request(
-            "PUT",
-            f"/applications/{application_id}/guilds/{guild_id}/commands",
-            body=commands,
-            authorize=True,
-        )
 
     async def fetch_global_application_commands(self, application_id: str):
         return await self.request(

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -296,7 +296,12 @@ class HTTPClient:
 
     async def get_channel_messages(): pass
     async def get_channel_message(): pass
-    async def create_message(): pass
+
+    async def create_message(self, channel_id: str, data: Any):
+        return await self.request(
+            "POST", f"/channels/{channel_id}/messages", body=data, authorize=True
+        )
+
     async def crosspost_message(): pass
     async def create_reaction(): pass
     async def delete_own_reaction(): pass

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -325,7 +325,23 @@ class HTTPClient:
 
     async def get_guild_bans(): pass
     async def get_guild_ban(): pass
-    async def create_guild_ban(): pass
+
+    async def create_guild_ban(
+        self, 
+        guild_id: str, 
+        user_id: str, 
+        delete_message_seconds: int = 0,
+        *,
+        reason: Optional[str] = None
+    ):
+        return await self.request(
+            "PUT",
+            f"/guilds/{guild_id}/bans/{user_id}",
+            authorize=True,
+            body={"delete_message_seconds": delete_message_seconds},
+            reason=reason
+        )
+
     async def remove_guild_ban(): pass
     async def bulk_guild_ban(): pass
     async def get_guild_roles(): pass
@@ -601,16 +617,6 @@ class HTTPClient:
         )
         
     # end todo
-
-    async def ban_user(
-        self, guild_id: str, user_id: str, delete_message_seconds: int = 0
-    ):
-        return await self.request(
-            "PUT",
-            f"/guilds/{guild_id}/bans/{user_id}",
-            authorize=True,
-            body={"delete_message_seconds": delete_message_seconds},
-        )
 
     async def send_interaction_callback(
         self, interaction_id: str, interaction_token: str, data: Any

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -397,7 +397,22 @@ class HTTPClient:
         return await self.request("GET", f"/guilds/{guild_id}/roles", authorize=True)
 
     async def get_guild_role(): pass
-    async def create_guild_role(): pass
+
+    async def create_guild_role(
+        self, 
+        guild_id: str, 
+        payload: Dict[str, Any],
+        *,
+        reason: Optional[str] = None
+    ):
+        return await self.request(
+            "POST", 
+            f"/guilds/{guild_id}/roles", 
+            body=payload, 
+            authorize=True,
+            reason=reason
+        )
+
     async def modify_guild_role_positions(): pass
     async def modify_guild_role(): pass
     async def modify_guild_mfa_level(): pass
@@ -689,10 +704,6 @@ class HTTPClient:
 
     # end todo
 
-    async def create_guild_role(self, guild_id: str, payload: Dict[str, Any]):
-        return await self.request(
-            "POST", f"/guilds/{guild_id}/roles", body=payload, authorize=True
-        )
 
     async def edit_guild_role_position(self, guild_id: str, payload: Dict[str, Any]):
         return await self.request(

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -77,7 +77,8 @@ class HTTPClient:
 
     async def get_global_application_commands(
         self, 
-        application_id: str, 
+        application_id: str,
+        *,
         with_localizations: bool = False
     ):
         return await self.request(
@@ -506,12 +507,6 @@ class HTTPClient:
             "GET", f"/channels/{channel_id}/messages", params=params, authorize=True
         )
 
-    async def send_webhook_message(
-        self, webhook_id: str, webhook_token: str, form: aiohttp.MultipartWriter
-    ):
-        return await self.request(
-            "POST", f"/webhooks/{webhook_id}/{webhook_token}", body=form
-        )
 
     async def delete_webhook_message(
         self, webhook_id: str, webhook_token: str, message_id: str

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -300,7 +300,18 @@ class HTTPClient:
             reason=reason
         )
 
-    async def modify_guild_channel_positions(): pass
+    async def modify_guild_channel_positions(
+        self, 
+        guild_id: str, 
+        payload: Dict[str, Any]
+    ):
+        return await self.request(
+            "PATCH", 
+            f"/guilds/{guild_id}/channels", 
+            body=payload, 
+            authorize=True
+        )
+
     async def list_active_guild_threads(): pass
 
     async def get_guild_member(self, guild_id: str, user_id: str):
@@ -677,11 +688,6 @@ class HTTPClient:
         )
 
     # end todo
-
-    async def edit_guild_channel_position(self, guild_id: str, payload: Dict[str, Any]):
-        return await self.request(
-            "PATCH", f"/guilds/{guild_id}/channels", body=payload, authorize=True
-        )
 
     async def create_guild_role(self, guild_id: str, payload: Dict[str, Any]):
         return await self.request(

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -424,11 +424,6 @@ class HTTPClient:
             authorize=True,
         )
 
-    async def send_message(self, channel_id: str, data: Any):
-        return await self.request(
-            "POST", f"/channels/{channel_id}/messages", body=data, authorize=True
-        )
-
     async def create_dm_channel(self, payload: Dict[str, Any]):
         return await self.request(
             "POST", "/users/@me/channels", body=payload, authorize=True

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -373,7 +373,15 @@ class HTTPClient:
     async def get_current_user_guilds(): pass
     async def get_current_user_guild_member(): pass
     async def leave_guild(): pass
-    async def create_dm(): pass
+
+    async def create_dm(elf, payload: Dict[str, Any]):
+        return await self.request(
+            "POST", 
+            "/users/@me/channels", 
+            body=payload, 
+            authorize=True
+        )
+
     async def create_group_dm(): pass
     async def get_current_user_connections(): pass
     async def get_current_user_application_role_connection(): pass
@@ -422,11 +430,6 @@ class HTTPClient:
             "DELETE",
             f"/applications/{application_id}/commands/{command_id}",
             authorize=True,
-        )
-
-    async def create_dm_channel(self, payload: Dict[str, Any]):
-        return await self.request(
-            "POST", "/users/@me/channels", body=payload, authorize=True
         )
 
     async def fetch_channel(self, channel_id: str):

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -235,7 +235,22 @@ class HTTPClient:
 
     async def list_guild_emojis(): pass
     async def get_guild_emoji(): pass
-    async def create_guild_emoji(): pass
+
+    async def create_guild_emoji(
+        self, 
+        guild_id: str, 
+        payload: Dict[str, Any],
+        *,
+        reason: Optional[str] = None
+    ):
+        return await self.request(
+            "POST", 
+            f"/guilds/{guild_id}/emojis", 
+            body=payload, 
+            authorize=True,
+            reason=reason
+        )
+
     async def modify_guild_emoji(): pass
     async def delete_guild_emoji(): pass
     async def list_application_emojis(): pass
@@ -732,11 +747,6 @@ class HTTPClient:
         )
 
     # end todo
-
-    async def create_guild_emoji(self, guild_id: str, payload: Dict[str, Any]):
-        return await self.request(
-            "POST", f"/guilds/{guild_id}/emojis", body=payload, authorize=True
-        )
 
     async def create_webhook(self, channel_id: str, payload: Dict[str, Any]):
         return await self.request(

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -152,16 +152,16 @@ class HTTPClient:
         return await self.request("GET", f"/channels/{channel_id}", authorize=True)
 
     async def modify_channel(
-        self, 
-        channel_id: str, 
+        self,
+        channel_id: str,
         payload: Dict[str, Any],
         *,
         reason: Optional[str] = None
     ):
         return await self.request(
-            "PATCH", 
-            f"/channels/{channel_id}", 
-            body=payload, 
+            "PATCH",
+            f"/channels/{channel_id}",
+            body=payload,
             authorize=True,
             reason=reason
         )
@@ -286,29 +286,29 @@ class HTTPClient:
         return await self.request("GET", f"/guilds/{guild_id}/channels", authorize=True)
 
     async def create_guild_channel(
-        self, 
-        guild_id: str, 
+        self,
+        guild_id: str,
         payload: Dict[str, Any],
         *,
         reason: Optional[str] = None
     ):
         return await self.request(
-            "POST", 
-            f"/guilds/{guild_id}/channels", 
-            body=payload, 
+            "POST",
+            f"/guilds/{guild_id}/channels",
+            body=payload,
             authorize=True,
             reason=reason
         )
 
     async def modify_guild_channel_positions(
-        self, 
-        guild_id: str, 
+        self,
+        guild_id: str,
         payload: Dict[str, Any]
     ):
         return await self.request(
-            "PATCH", 
-            f"/guilds/{guild_id}/channels", 
-            body=payload, 
+            "PATCH",
+            f"/guilds/{guild_id}/channels",
+            body=payload,
             authorize=True
         )
 
@@ -316,8 +316,8 @@ class HTTPClient:
 
     async def get_guild_member(self, guild_id: str, user_id: str):
         return await self.request(
-            "GET", 
-            f"/guilds/{guild_id}/members/{user_id}", 
+            "GET",
+            f"/guilds/{guild_id}/members/{user_id}",
             authorize=True
         )
 
@@ -358,15 +358,15 @@ class HTTPClient:
         )
 
     async def remove_guild_member(
-        self, 
-        guild_id: str, 
-        user_id: str, 
-        *, 
+        self,
+        guild_id: str,
+        user_id: str,
+        *,
         reason: Optional[str] = None
     ):
         return await self.request(
-            "DELETE", 
-            f"/guilds/{guild_id}/members/{user_id}", 
+            "DELETE",
+            f"/guilds/{guild_id}/members/{user_id}",
             authorize=True,
             reason=reason
         )
@@ -375,9 +375,9 @@ class HTTPClient:
     async def get_guild_ban(): pass
 
     async def create_guild_ban(
-        self, 
-        guild_id: str, 
-        user_id: str, 
+        self,
+        guild_id: str,
+        user_id: str,
         delete_message_seconds: int = 0,
         *,
         reason: Optional[str] = None
@@ -399,47 +399,47 @@ class HTTPClient:
     async def get_guild_role(): pass
 
     async def create_guild_role(
-        self, 
-        guild_id: str, 
+        self,
+        guild_id: str,
         payload: Dict[str, Any],
         *,
         reason: Optional[str] = None
     ):
         return await self.request(
-            "POST", 
-            f"/guilds/{guild_id}/roles", 
-            body=payload, 
+            "POST",
+            f"/guilds/{guild_id}/roles",
+            body=payload,
             authorize=True,
             reason=reason
         )
 
     async def modify_guild_role_positions(
-        self, 
-        guild_id: str, 
+        self,
+        guild_id: str,
         payload: Dict[str, Any],
         *,
         reason: Optional[str] = None
     ):
         return await self.request(
-            "PATCH", 
-            f"/guilds/{guild_id}/roles", 
-            body=payload, 
+            "PATCH",
+            f"/guilds/{guild_id}/roles",
+            body=payload,
             authorize=True,
             reason=reason
         )
 
     async def modify_guild_role(
-        self, 
-        guild_id: str, 
-        role_id: str, 
+        self,
+        guild_id: str,
+        role_id: str,
         payload: Dict[str, Any],
         *,
         reason: Optional[str] = None
     ):
         return await self.request(
-            "PATCH", 
-            f"/guilds/{guild_id}/roles/{role_id}", 
-            body=payload, 
+            "PATCH",
+            f"/guilds/{guild_id}/roles/{role_id}",
+            body=payload,
             authorize=True,
             reason=reason
         )

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -272,7 +272,14 @@ class HTTPClient:
     async def create_guild_channel(): pass
     async def modify_guild_channel_positions(): pass
     async def list_active_guild_threads(): pass
-    async def get_guild_member(): pass
+
+    async def get_guild_member(self, guild_id: str, user_id: str):
+        return await self.request(
+            "GET", 
+            f"/guilds/{guild_id}/members/{user_id}", 
+            authorize=True
+        )
+
     async def list_guild_members(): pass
     async def search_guild_members(): pass
     async def add_guild_member(): pass
@@ -615,8 +622,6 @@ class HTTPClient:
         return await self.request(
             "GET", f"/webhooks/{webhook_id}/{webhook_token}/messages/@original"
         )
-        
-    # end todo
 
     async def send_interaction_callback(
         self, interaction_id: str, interaction_token: str, data: Any
@@ -632,10 +637,7 @@ class HTTPClient:
             "GET", f"/guilds/{guild_id}?with_counts=true", authorize=True
         )
 
-    async def fetch_guild_member(self, guild_id: str, user_id: str):
-        return await self.request(
-            "GET", f"/guilds/{guild_id}/members/{user_id}", authorize=True
-        )
+    # end todo
 
     async def fetch_guild_channels(self, guild_id: str):
         return await self.request("GET", f"/guilds/{guild_id}/channels", authorize=True)

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -151,7 +151,20 @@ class HTTPClient:
     async def get_channel(self, channel_id: str):
         return await self.request("GET", f"/channels/{channel_id}", authorize=True)
 
-    async def modify_channel(): pass
+    async def modify_channel(
+        self, 
+        channel_id: str, 
+        payload: Dict[str, Any],
+        *,
+        reason: Optional[str] = None
+    ):
+        return await self.request(
+            "PATCH", 
+            f"/channels/{channel_id}", 
+            body=payload, 
+            authorize=True,
+            reason=reason
+        )
 
     async def delete_or_close_channel(
         self,
@@ -664,11 +677,6 @@ class HTTPClient:
         )
 
     # end todo
-
-    async def edit_channel(self, channel_id: str, payload: Dict[str, Any]):
-        return await self.request(
-            "PATCH", f"/channels/{channel_id}", body=payload, authorize=True
-        )
 
     async def edit_guild_channel_position(self, guild_id: str, payload: Dict[str, Any]):
         return await self.request(

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -337,7 +337,15 @@ class HTTPClient:
     async def delete_all_reactions(): pass
     async def delete_all_reactions_for_emoji(): pass
     async def edit_message(): pass
-    async def delete_message(): pass
+
+    async def delete_message(self, channel_id: str, message_id: str, reason: Optional[str] = None):
+        await self.request(
+            "DELETE", 
+            f"/channels/{channel_id}/messages/{message_id}", 
+            authorize=True,
+            reason=reason
+        )
+
     async def bulk_delete_messages(): pass
 
     # Poll Resource
@@ -462,11 +470,6 @@ class HTTPClient:
     async def fetch_channel_messages(self, channel_id: str, params: Dict[str, Any]):
         return await self.request(
             "GET", f"/channels/{channel_id}/messages", params=params, authorize=True
-        )
-
-    async def delete_channel_message(self, channel_id: str, message_id: str):
-        await self.request(
-            "DELETE", f"/channels/{channel_id}/messages/{message_id}", authorize=True
         )
 
     async def delete_channel_messages(self, channel_id: str, payload: Dict[str, Any]):

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -434,7 +434,13 @@ class HTTPClient:
             authorize=True
         )
 
-    async def crosspost_message(): pass
+    async def crosspost_message(self, channel_id: str, message_id: str):
+        return await self.request(
+            "POST",
+            f"/channels/{channel_id}/messages/{message_id}/crosspost",
+            authorize=True,
+        )
+
     async def create_reaction(): pass
     async def delete_own_reaction(): pass
     async def delete_user_reaction(): pass
@@ -658,13 +664,6 @@ class HTTPClient:
         )
 
     # end todo
-
-    async def crosspost_channel_message(self, channel_id: str, message_id: str):
-        return await self.request(
-            "POST",
-            f"/channels/{channel_id}/messages/{message_id}/crosspost",
-            authorize=True,
-        )
 
     async def edit_channel(self, channel_id: str, payload: Dict[str, Any]):
         return await self.request(

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -692,7 +692,15 @@ class HTTPClient:
         )
 
     async def modify_webhook_with_token(): pass
-    async def delete_webhook(): pass
+
+    async def delete_webhook(self, webhook_id: str, *, reason: Optional[str] = None):
+        return await self.request(
+            "DELETE", 
+            f"/webhooks/{webhook_id}", 
+            authorize=True,
+            reason=reason
+        )
+
     async def delete_webhook_with_token(): pass
     async def execute_webhook(): pass
     async def execute_slack_compatible_webhook(): pass
@@ -786,15 +794,12 @@ class HTTPClient:
             "POST", f"/webhooks/{webhook_id}/{webhook_token}", body=data, params=params
         )
 
-    # end todo
-
     async def fetch_webhook(self, webhook_id: str, webhook_token: Optional[str] = None):
         if webhook_token:
             return await self.request("GET", f"/webhooks/{webhook_id}/{webhook_token}")
         return await self.request("GET", f"/webhooks/{webhook_id}", authorize=True)
 
-    async def delete_webhook(self, webhook_id: str):
-        return await self.request("DELETE", f"/webhooks/{webhook_id}", authorize=True)
+    # end todo
 
     async def create_message_reaction(
         self, channel_id: str, message_id: str, emoji: str

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -179,7 +179,15 @@ class HTTPClient:
     async def follow_announcement_channel(): pass
     async def trigger_typing_indicator(): pass
     async def get_pinned_messages(): pass
-    async def pin_message(): pass
+
+    async def pin_message(self, channel_id: str, message_id: str, reason: Optional[str] = None):
+        await self.request(
+            "PUT", 
+            f"/channels/{channel_id}/messages/{message_id}/pin", 
+            authorize=True,
+            reason=reason
+        )
+
     async def unpin_message(): pass
     async def group_dm_add_recipient(): pass
     async def group_dm_remove_recipient(): pass
@@ -482,11 +490,6 @@ class HTTPClient:
     async def fetch_channel_messages(self, channel_id: str, params: Dict[str, Any]):
         return await self.request(
             "GET", f"/channels/{channel_id}/messages", params=params, authorize=True
-        )
-
-    async def pin_channel_message(self, channel_id: str, message_id: str):
-        await self.request(
-            "PUT", f"/channels/{channel_id}/messages/{message_id}/pin", authorize=True
         )
 
     async def unpin_channel_message(self, channel_id: str, message_id: str):

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -268,7 +268,10 @@ class HTTPClient:
     async def get_guild_preview(): pass
     async def modify_guild(): pass
     async def delete_guild(): pass
-    async def get_guild_channels(): pass
+
+    async def get_guild_channels(self, guild_id: str):
+        return await self.request("GET", f"/guilds/{guild_id}/channels", authorize=True)
+
     async def create_guild_channel(): pass
     async def modify_guild_channel_positions(): pass
     async def list_active_guild_threads(): pass
@@ -638,9 +641,6 @@ class HTTPClient:
         )
 
     # end todo
-
-    async def fetch_guild_channels(self, guild_id: str):
-        return await self.request("GET", f"/guilds/{guild_id}/channels", authorize=True)
 
     async def fetch_guild_roles(self, guild_id: str):
         return await self.request("GET", f"/guilds/{guild_id}/roles", authorize=True)

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -283,10 +283,43 @@ class HTTPClient:
 
     async def modify_guild_emoji(): pass
     async def delete_guild_emoji(): pass
-    async def list_application_emojis(): pass
-    async def get_application_emoji(): pass
-    async def create_application_emoji(): pass
-    async def modify_application_emoji(): pass
+
+    async def list_application_emojis(self):
+        return await self.request(
+            "GET",
+            f"/applications/{self.application_id}/emojis",
+            authorize=True,
+        )
+
+    async def get_application_emoji(self, emoji_id: str):
+        return await self.request(
+            "GET",
+            f"/applications/{self.application_id}/emojis/{emoji_id}",
+            authorize=True,
+        )
+
+    async def create_application_emoji(self, payload: Dict[str, Any]):
+        return await self.request(
+            "POST",
+            f"/applications/{self.application_id}/emojis",
+            body=payload,
+            authorize=True,
+        )
+
+    async def modify_application_emoji(self, emoji_id: str, name: str):
+        return await self.request(
+            "PATCH",
+            f"/applications/{self.application_id}/emojis/{emoji_id}",
+            body={"name": name},
+            authorize=True,
+        )
+    
+    async def delete_application_emoji(self, emoji_id: str):
+        return await self.request(
+            "DELETE",
+            f"/applications/{self.application_id}/emojis/{emoji_id}",
+            authorize=True,
+        )
     
     # Entitlements Resource
     # https://discord.com/developers/docs/resources/entitlement#entitlements-resource
@@ -901,44 +934,5 @@ class HTTPClient:
             "GET",
             f"/channels/{channel_id}/polls/{message_id}/answers/{answer_id}",
             params=params,
-            authorize=True,
-        )
-
-    # end todo
-
-    async def fetch_application_emojis(self):
-        return await self.request(
-            "GET",
-            f"/applications/{self.application_id}/emojis",
-            authorize=True,
-        )
-
-    async def fetch_application_emoji(self, emoji_id: str):
-        return await self.request(
-            "GET",
-            f"/applications/{self.application_id}/emojis/{emoji_id}",
-            authorize=True,
-        )
-
-    async def create_application_emoji(self, payload: Dict[str, Any]):
-        return await self.request(
-            "POST",
-            f"/applications/{self.application_id}/emojis",
-            body=payload,
-            authorize=True,
-        )
-
-    async def edit_application_emoji(self, emoji_id: str, payload: Dict[str, Any]):
-        return await self.request(
-            "PATCH",
-            f"/applications/{self.application_id}/emojis/{emoji_id}",
-            body=payload,
-            authorize=True,
-        )
-
-    async def delete_application_emoji(self, emoji_id: str):
-        return await self.request(
-            "DELETE",
-            f"/applications/{self.application_id}/emojis/{emoji_id}",
             authorize=True,
         )

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -262,7 +262,22 @@ class HTTPClient:
     async def modify_guild_member(): pass
     async def modify_current_member(): pass
     async def modify_current_user_nick(): pass
-    async def add_guild_member_role(): pass
+
+    async def add_guild_member_role(
+        self, 
+        guild_id: str, 
+        user_id: str, 
+        role_id: str, 
+        *, 
+        reason: Optional[str] = None
+    ):
+        return await self.request(
+            "PUT",
+            f"/guilds/{guild_id}/members/{user_id}/roles/{role_id}",
+            authorize=True,
+            reason=reason
+        )
+
     async def remove_guild_member_role(): pass
     async def remove_guild_member(): pass
     async def get_guild_bans(): pass
@@ -508,7 +523,6 @@ class HTTPClient:
             "GET", f"/channels/{channel_id}/messages", params=params, authorize=True
         )
 
-
     async def delete_webhook_message(
         self, webhook_id: str, webhook_token: str, message_id: str
     ):
@@ -533,16 +547,8 @@ class HTTPClient:
         return await self.request(
             "GET", f"/webhooks/{webhook_id}/{webhook_token}/messages/@original"
         )
-
-    async def add_role(
-        self, guild_id: str, user_id: str, role_id: str, *, reason: Optional[str] = None
-    ):
-        return await self.request(
-            "PUT",
-            f"/guilds/{guild_id}/members/{user_id}/roles/{role_id}",
-            authorize=True,
-            reason=reason
-        )
+        
+    # end todo
 
     async def remove_role(self, guild_id: str, user_id: str, role_id: str):
         return await self.request(

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -272,7 +272,21 @@ class HTTPClient:
     async def get_guild_channels(self, guild_id: str):
         return await self.request("GET", f"/guilds/{guild_id}/channels", authorize=True)
 
-    async def create_guild_channel(): pass
+    async def create_guild_channel(
+        self, 
+        guild_id: str, 
+        payload: Dict[str, Any],
+        *,
+        reason: Optional[str] = None
+    ):
+        return await self.request(
+            "POST", 
+            f"/guilds/{guild_id}/channels", 
+            body=payload, 
+            authorize=True,
+            reason=reason
+        )
+
     async def modify_guild_channel_positions(): pass
     async def list_active_guild_threads(): pass
 
@@ -644,11 +658,6 @@ class HTTPClient:
         )
 
     # end todo
-
-    async def create_guild_channel(self, guild_id: str, payload: Dict[str, Any]):
-        return await self.request(
-            "POST", f"/guilds/{guild_id}/channels", body=payload, authorize=True
-        )
 
     async def crosspost_channel_message(self, channel_id: str, message_id: str):
         return await self.request(

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -82,8 +82,8 @@ class HTTPClient:
     async def delete_global_application_command(): pass
 
     async def bulk_overwrite_global_application_commands(
-        self, 
-        application_id: str, 
+        self,
+        application_id: str,
         commands: List[Dict[str, Any]]
     ):
         return await self.request(
@@ -100,9 +100,9 @@ class HTTPClient:
     async def delete_guild_application_command(): pass
 
     async def bulk_overwrite_guild_application_commands(
-        self, 
-        application_id: str, 
-        guild_id: str, 
+        self,
+        application_id: str,
+        guild_id: str,
         commands: List[Dict[str, Any]]
     ):
         return await self.request(
@@ -153,10 +153,15 @@ class HTTPClient:
 
     async def modify_channel(): pass
 
-    async def delete_or_close_channel(self, channel_id: str, reason: Optional[str] = None):
+    async def delete_or_close_channel(
+        self,
+        channel_id: str,
+        *,
+        reason: Optional[str] = None
+    ):
         return await self.request(
-            "DELETE", 
-            f"/channels/{channel_id}", 
+            "DELETE",
+            f"/channels/{channel_id}",
             authorize=True,
             reason=reason
         )
@@ -169,15 +174,27 @@ class HTTPClient:
     async def trigger_typing_indicator(): pass
     async def get_pinned_messages(): pass
 
-    async def pin_message(self, channel_id: str, message_id: str, reason: Optional[str] = None):
+    async def pin_message(
+        self,
+        channel_id: str,
+        message_id: str,
+        *,
+        reason: Optional[str] = None
+    ):
         await self.request(
-            "PUT", 
-            f"/channels/{channel_id}/messages/{message_id}/pin", 
+            "PUT",
+            f"/channels/{channel_id}/messages/{message_id}/pin",
             authorize=True,
             reason=reason
         )
 
-    async def unpin_message(self, channel_id: str, message_id: str, reason: Optional[str] = None):
+    async def unpin_message(
+        self,
+        channel_id: str,
+        message_id: str,
+        *,
+        reason: Optional[str] = None
+    ):
         await self.request(
             "DELETE",
             f"/channels/{channel_id}/messages/{message_id}/pin",
@@ -264,11 +281,11 @@ class HTTPClient:
     async def modify_current_user_nick(): pass
 
     async def add_guild_member_role(
-        self, 
-        guild_id: str, 
-        user_id: str, 
-        role_id: str, 
-        *, 
+        self,
+        guild_id: str,
+        user_id: str,
+        role_id: str,
+        *,
         reason: Optional[str] = None
     ):
         return await self.request(
@@ -278,7 +295,20 @@ class HTTPClient:
             reason=reason
         )
 
-    async def remove_guild_member_role(): pass
+    async def remove_guild_member_role(
+        self,
+        guild_id: str,
+        user_id: str,
+        role_id: str,
+        *,
+        reason: Optional[str] = None
+    ):
+        return await self.request(
+            "DELETE",
+            f"/guilds/{guild_id}/members/{user_id}/roles/{role_id}",
+            authorize=True,
+        )
+
     async def remove_guild_member(): pass
     async def get_guild_bans(): pass
     async def get_guild_ban(): pass
@@ -335,16 +365,16 @@ class HTTPClient:
 
     async def get_channel_message(self, channel_id: str, message_id: str):
         return await self.request(
-            "GET", 
-            f"/channels/{channel_id}/messages/{message_id}", 
+            "GET",
+            f"/channels/{channel_id}/messages/{message_id}",
             authorize=True
         )
 
     async def create_message(self, channel_id: str, data: Any):
         return await self.request(
-            "POST", 
-            f"/channels/{channel_id}/messages", 
-            body=data, 
+            "POST",
+            f"/channels/{channel_id}/messages",
+            body=data,
             authorize=True
         )
 
@@ -364,18 +394,25 @@ class HTTPClient:
             authorize=True,
         )
 
-    async def delete_message(self, channel_id: str, message_id: str, reason: Optional[str] = None):
+    async def delete_message(
+        self,
+        channel_id: str,
+        message_id: str,
+        *,
+        reason: Optional[str] = None
+    ):
         await self.request(
-            "DELETE", 
-            f"/channels/{channel_id}/messages/{message_id}", 
+            "DELETE",
+            f"/channels/{channel_id}/messages/{message_id}",
             authorize=True,
             reason=reason
         )
 
     async def bulk_delete_messages(
-        self, 
-        channel_id: str, 
-        payload: Dict[str, Any], 
+        self,
+        channel_id: str,
+        payload: Dict[str, Any],
+        *,
         reason: Optional[str] = None
     ):
         await self.request(
@@ -449,9 +486,9 @@ class HTTPClient:
 
     async def create_dm(elf, payload: Dict[str, Any]):
         return await self.request(
-            "POST", 
-            "/users/@me/channels", 
-            body=payload, 
+            "POST",
+            "/users/@me/channels",
+            body=payload,
             authorize=True
         )
 
@@ -491,14 +528,14 @@ class HTTPClient:
     # todo
 
     async def get_global_application_commands(
-        self, 
+        self,
         application_id: str,
         *,
         with_localizations: bool = False
     ):
         return await self.request(
-            "GET", 
-            f"/applications/{application_id}/commands", 
+            "GET",
+            f"/applications/{application_id}/commands",
             authorize=True,
             with_localizations=with_localizations
         )
@@ -549,13 +586,6 @@ class HTTPClient:
         )
         
     # end todo
-
-    async def remove_role(self, guild_id: str, user_id: str, role_id: str):
-        return await self.request(
-            "DELETE",
-            f"/guilds/{guild_id}/members/{user_id}/roles/{role_id}",
-            authorize=True,
-        )
 
     async def fetch_user(self, user_id: str):
         return await self.request("GET", f"/users/{user_id}", authorize=True)

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -218,7 +218,22 @@ class HTTPClient:
     async def group_dm_add_recipient(): pass
     async def group_dm_remove_recipient(): pass
     async def start_thread_from_message(): pass
-    async def start_thread_without_message(): pass
+
+    async def start_thread_without_message(
+        self, 
+        channel_id: str, 
+        payload: Dict[str, Any], 
+        *,
+        reason: Optional[str] = None
+    ):
+        return await self.request(
+            "POST",
+            f"/channels/{channel_id}/threads",
+            body=payload,
+            authorize=True,
+            reason=reason
+        )
+
     async def start_thread_in_forum_or_media_channel(): pass
     async def join_thread(): pass
     async def add_thread_member(): pass
@@ -856,17 +871,6 @@ class HTTPClient:
         )
 
     # end todo
-
-    async def start_thread_without_message(
-        self, channel_id: str, payload: Dict[str, Any], reason: Optional[str] = None
-    ):
-        return await self.request(
-            "POST",
-            f"/channels/{channel_id}/threads",
-            body=payload,
-            reason=reason,
-            authorize=True
-        )
 
     async def start_thread_with_message(
         self,

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -524,7 +524,15 @@ class HTTPClient:
             authorize=True,
         )
 
-    async def create_reaction(): pass
+    async def create_reaction(
+        self, channel_id: str, message_id: str, emoji: str
+    ):
+        return await self.request(
+            "PUT",
+            f"/channels/{channel_id}/messages/{message_id}/reactions/{emoji}/@me",
+            authorize=True,
+        )
+
     async def delete_own_reaction(): pass
     async def delete_user_reaction(): pass
     async def get_reactions(): pass
@@ -800,16 +808,7 @@ class HTTPClient:
         return await self.request("GET", f"/webhooks/{webhook_id}", authorize=True)
 
     # end todo
-
-    async def create_message_reaction(
-        self, channel_id: str, message_id: str, emoji: str
-    ):
-        return await self.request(
-            "PUT",
-            f"/channels/{channel_id}/messages/{message_id}/reactions/{emoji}/@me",
-            authorize=True,
-        )
-
+    
     async def delete_message_reaction(self, message_id: str, emoji: str, user_id: str):
         return await self.request(
             "DELETE",

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -188,7 +188,14 @@ class HTTPClient:
             reason=reason
         )
 
-    async def unpin_message(): pass
+    async def unpin_message(self, channel_id: str, message_id: str, reason: Optional[str] = None):
+        await self.request(
+            "DELETE",
+            f"/channels/{channel_id}/messages/{message_id}/pin",
+            authorize=True,
+            reason=reason
+        )
+
     async def group_dm_add_recipient(): pass
     async def group_dm_remove_recipient(): pass
     async def start_thread_from_message(): pass
@@ -490,13 +497,6 @@ class HTTPClient:
     async def fetch_channel_messages(self, channel_id: str, params: Dict[str, Any]):
         return await self.request(
             "GET", f"/channels/{channel_id}/messages", params=params, authorize=True
-        )
-
-    async def unpin_channel_message(self, channel_id: str, message_id: str):
-        await self.request(
-            "DELETE",
-            f"/channels/{channel_id}/messages/{message_id}/pin",
-            authorize=True,
         )
 
     async def edit_channel_message(self, channel_id: str, message_id: str, data: Any):

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -159,7 +159,9 @@ class HTTPClient:
     # Channels Resource
     # https://discord.com/developers/docs/resources/channel#channels-resource
 
-    async def get_channel(): pass
+    async def get_channel(self, channel_id: str):
+        return await self.request("GET", f"/channels/{channel_id}", authorize=True)
+
     async def modify_channel(): pass
     async def delete_or_close_channel(): pass # "closes" a dm channel
     async def edit_channel_permissions(): pass
@@ -442,9 +444,6 @@ class HTTPClient:
             f"/applications/{application_id}/commands/{command_id}",
             authorize=True,
         )
-
-    async def fetch_channel(self, channel_id: str):
-        return await self.request("GET", f"/channels/{channel_id}", authorize=True)
 
     async def delete_channel(self, channel_id: str):
         return await self.request("DELETE", f"/channels/{channel_id}", authorize=True)

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -30,9 +30,9 @@ class HTTPClient:
         path: str,
         *,
         body: Union[aiohttp.MultipartWriter, Any] = None,
-        params: Optional[Dict[str, Any]] = None,
         authorize: bool = False,
         reason: Optional[str] = None,
+        **params: Dict[str, Any]
     ):
         headers = {"User-Agent": self.USER_AGENT}
         if authorize:
@@ -75,11 +75,16 @@ class HTTPClient:
     # Application Commands
     # https://discord.com/developers/docs/interactions/application-commands#application-commands
 
-    async def get_global_application_commands(self, application_id: str):
+    async def get_global_application_commands(
+        self, 
+        application_id: str, 
+        with_localizations: bool = False
+    ):
         return await self.request(
             "GET", 
             f"/applications/{application_id}/commands", 
-            authorize=True
+            authorize=True,
+            with_localizations=with_localizations
         )
     
     async def create_global_application_command(): pass
@@ -106,7 +111,10 @@ class HTTPClient:
     async def delete_guild_application_command(): pass
 
     async def bulk_overwrite_guild_application_commands(
-        self, application_id: str, guild_id: str, commands: List[Dict[str, Any]]
+        self, 
+        application_id: str, 
+        guild_id: str, 
+        commands: List[Dict[str, Any]]
     ):
         return await self.request(
             "PUT",
@@ -299,7 +307,10 @@ class HTTPClient:
 
     async def create_message(self, channel_id: str, data: Any):
         return await self.request(
-            "POST", f"/channels/{channel_id}/messages", body=data, authorize=True
+            "POST", 
+            f"/channels/{channel_id}/messages", 
+            body=data, 
+            authorize=True
         )
 
     async def crosspost_message(): pass

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -632,7 +632,11 @@ class HTTPClient:
     # https://discord.com/developers/docs/resources/poll#poll-resource
 
     async def get_answer_voters(): pass
-    async def end_poll(): pass
+
+    async def end_poll(self, channel_id: str, message_id: str):
+        return await self.request(
+            "POST", f"/channels/{channel_id}/polls/{message_id}/expire", authorize=True
+        )
 
     # SKU Resource
     # https://discord.com/developers/docs/resources/sku#sku-resource
@@ -885,8 +889,6 @@ class HTTPClient:
             authorize=True,
         )
 
-    # end todo
-
     async def fetch_answer_voters(
         self,
         channel_id: str,
@@ -902,10 +904,7 @@ class HTTPClient:
             authorize=True,
         )
 
-    async def end_poll(self, channel_id: str, message_id: str):
-        return await self.request(
-            "POST", f"/channels/{channel_id}/polls/{message_id}/expire", authorize=True
-        )
+    # end todo
 
     async def fetch_application_emojis(self):
         return await self.request(

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -75,7 +75,13 @@ class HTTPClient:
     # Application Commands
     # https://discord.com/developers/docs/interactions/application-commands#application-commands
 
-    async def get_global_application_commands(): pass
+    async def get_global_application_commands(self, application_id: str):
+        return await self.request(
+            "GET", 
+            f"/applications/{application_id}/commands", 
+            authorize=True
+        )
+    
     async def create_global_application_command(): pass
     async def get_global_application_command(): pass
     async def edit_global_application_command(): pass
@@ -394,12 +400,6 @@ class HTTPClient:
     async def delete_webhook_message(): pass
 
     # todo
-
-
-    async def fetch_global_application_commands(self, application_id: str):
-        return await self.request(
-            "GET", f"/applications/{application_id}/commands", authorize=True
-        )
 
     async def edit_client(self, payload: Dict[str, Any]):
         return await self.request("PATCH", "/users/@me", body=payload, authorize=True)

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -163,7 +163,15 @@ class HTTPClient:
         return await self.request("GET", f"/channels/{channel_id}", authorize=True)
 
     async def modify_channel(): pass
-    async def delete_or_close_channel(): pass # "closes" a dm channel
+
+    async def delete_or_close_channel(self, channel_id: str, reason: Optional[str] = None):
+        return await self.request(
+            "DELETE", 
+            f"/channels/{channel_id}", 
+            authorize=True,
+            reason=reason
+        )
+
     async def edit_channel_permissions(): pass
     async def get_channel_invites(): pass
     async def create_channel_invite(): pass
@@ -445,9 +453,6 @@ class HTTPClient:
             authorize=True,
         )
 
-    async def delete_channel(self, channel_id: str):
-        return await self.request("DELETE", f"/channels/{channel_id}", authorize=True)
-
     async def fetch_channel_message(self, channel_id: str, message_id: str):
         return await self.request(
             "GET", f"/channels/{channel_id}/messages/{message_id}", authorize=True
@@ -529,8 +534,8 @@ class HTTPClient:
         return await self.request(
             "PUT",
             f"/guilds/{guild_id}/members/{user_id}/roles/{role_id}",
-            reason=reason,
             authorize=True,
+            reason=reason
         )
 
     async def remove_role(self, guild_id: str, user_id: str, role_id: str):
@@ -724,8 +729,8 @@ class HTTPClient:
             "POST",
             f"/channels/{channel_id}/threads",
             body=payload,
-            authorize=True,
             reason=reason,
+            authorize=True
         )
 
     async def start_thread_with_message(
@@ -739,8 +744,8 @@ class HTTPClient:
             "POST",
             f"/channels/{channel_id}/messages/{message_id}/threads",
             body=payload,
-            authorize=True,
             reason=reason,
+            authorize=True
         )
 
     async def fetch_answer_voters(

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -675,7 +675,22 @@ class HTTPClient:
     async def get_guild_webhooks(): pass
     async def get_webhook(): pass
     async def get_webhook_with_token(): pass
-    async def modify_webhook(): pass
+
+    async def modify_webhook(
+        self, 
+        webhook_id: str, 
+        payload: Dict[str, Any],
+        *,
+        reason: Optional[str] = None
+    ):
+        return await self.request(
+            "PATCH", 
+            f"/webhooks/{webhook_id}", 
+            body=payload, 
+            authorize=True,
+            reason=reason
+        )
+
     async def modify_webhook_with_token(): pass
     async def delete_webhook(): pass
     async def delete_webhook_with_token(): pass
@@ -760,8 +775,6 @@ class HTTPClient:
             "GET", f"/guilds/{guild_id}?with_counts=true", authorize=True
         )
 
-    # end todo
-
     async def execute_webhook(
         self,
         webhook_id: str,
@@ -773,10 +786,7 @@ class HTTPClient:
             "POST", f"/webhooks/{webhook_id}/{webhook_token}", body=data, params=params
         )
 
-    async def edit_webhook(self, webhook_id: str, payload: Dict[str, Any]):
-        return await self.request(
-            "PATCH", f"/webhooks/{webhook_id}", body=payload, authorize=True
-        )
+    # end todo
 
     async def fetch_webhook(self, webhook_id: str, webhook_token: Optional[str] = None):
         if webhook_token:

--- a/discohook/https.py
+++ b/discohook/https.py
@@ -428,7 +428,22 @@ class HTTPClient:
             reason=reason
         )
 
-    async def modify_guild_role(): pass
+    async def modify_guild_role(
+        self, 
+        guild_id: str, 
+        role_id: str, 
+        payload: Dict[str, Any],
+        *,
+        reason: Optional[str] = None
+    ):
+        return await self.request(
+            "PATCH", 
+            f"/guilds/{guild_id}/roles/{role_id}", 
+            body=payload, 
+            authorize=True,
+            reason=reason
+        )
+
     async def modify_guild_mfa_level(): pass
     async def delete_guild_role(): pass
     async def get_guild_prune_count(): pass
@@ -717,15 +732,6 @@ class HTTPClient:
         )
 
     # end todo
-
-
-
-    async def edit_guild_role(
-        self, guild_id: str, role_id: str, payload: Dict[str, Any]
-    ):
-        return await self.request(
-            "PATCH", f"/guilds/{guild_id}/roles/{role_id}", body=payload, authorize=True
-        )
 
     async def create_guild_emoji(self, guild_id: str, payload: Dict[str, Any]):
         return await self.request(

--- a/discohook/member.py
+++ b/discohook/member.py
@@ -84,7 +84,7 @@ class Member(User):
         reason: Optional[str]
             The reason for adding the role to be logged.
         """
-        return await self.client.http.add_role(
+        return await self.client.http.add_guild_member_role(
             self.guild_id, self.id, role_id, reason=reason
         )
 

--- a/discohook/member.py
+++ b/discohook/member.py
@@ -116,6 +116,6 @@ class Member(User):
         """
         if delete_message_seconds > 604800:
             raise ValueError("You can only delete messages for up to last 7 days.")
-        return await self.client.http.ban_user(
+        return await self.client.http.create_guild_ban(
             self.guild_id, self.id, delete_message_seconds
         )

--- a/discohook/member.py
+++ b/discohook/member.py
@@ -103,7 +103,7 @@ class Member(User):
         """
         Kick the member.
         """
-        return await self.client.http.kick_user(self.guild_id, self.id)
+        return await self.client.http.remove_guild_member(self.guild_id, self.id)
 
     async def ban(self, *, delete_message_seconds: int = 0):
         """

--- a/discohook/member.py
+++ b/discohook/member.py
@@ -88,7 +88,7 @@ class Member(User):
             self.guild_id, self.id, role_id, reason=reason
         )
 
-    async def remove_role(self, role_id: str):
+    async def remove_role(self, role_id: str, *, reason: Optional[str] = None):
         """
         Remove a role from the member.
 
@@ -97,15 +97,17 @@ class Member(User):
         role_id : str
             The ID of the role.
         """
-        return await self.client.http.remove_guild_member_role(self.guild_id, self.id, role_id)
+        return await self.client.http.remove_guild_member_role(
+            self.guild_id, self.id, role_id, reason=reason
+        )
 
-    async def kick(self):
+    async def kick(self, *, reason: Optional[str] = None):
         """
         Kick the member.
         """
-        return await self.client.http.remove_guild_member(self.guild_id, self.id)
+        return await self.client.http.remove_guild_member(self.guild_id, self.id, reason=reason)
 
-    async def ban(self, *, delete_message_seconds: int = 0):
+    async def ban(self, *, delete_message_seconds: int = 0, reason: Optional[str] = None):
         """
         Ban the member.
 
@@ -117,5 +119,5 @@ class Member(User):
         if delete_message_seconds > 604800:
             raise ValueError("You can only delete messages for up to last 7 days.")
         return await self.client.http.create_guild_ban(
-            self.guild_id, self.id, delete_message_seconds
+            self.guild_id, self.id, delete_message_seconds, reason=reason
         )

--- a/discohook/member.py
+++ b/discohook/member.py
@@ -97,7 +97,7 @@ class Member(User):
         role_id : str
             The ID of the role.
         """
-        return await self.client.http.remove_role(self.guild_id, self.id, role_id)
+        return await self.client.http.remove_guild_member_role(self.guild_id, self.id, role_id)
 
     async def kick(self):
         """

--- a/discohook/message.py
+++ b/discohook/message.py
@@ -365,7 +365,7 @@ class Message:
         )
         if view and view is not MISSING:
             self.client.load_view(view)
-        resp = await self.client.http.send_message(self.channel_id, payload)
+        resp = await self.client.http.create_message(self.channel_id, payload)
         return Message(self.client, await resp.json())
 
     async def add_reaction(self, emoji: Union[PartialEmoji, str]):

--- a/discohook/message.py
+++ b/discohook/message.py
@@ -284,7 +284,7 @@ class Message:
         )
         if view and view is not MISSING:
             self.client.load_view(view)
-        resp = await self.client.http.edit_channel_message(
+        resp = await self.client.http.edit_message(
             self.channel_id, self.id, payload
         )
         return Message(self.client, await resp.json())

--- a/discohook/message.py
+++ b/discohook/message.py
@@ -466,6 +466,6 @@ class Message:
             "auto_archive_duration": auto_archive_duration,
             "rate_limit_per_user": rate_limit_per_user,
         }
-        return await self.client.http.start_thread_with_message(
+        return await self.client.http.start_thread_from_message(
             self.channel_id, self.id, payload, reason
         )

--- a/discohook/message.py
+++ b/discohook/message.py
@@ -429,7 +429,7 @@ class Message:
         """
         Crossposts the message.
         """
-        resp = await self.client.http.crosspost_channel_message(
+        resp = await self.client.http.crosspost_message(
             self.channel_id, self.id
         )
         data = await resp.json()

--- a/discohook/message.py
+++ b/discohook/message.py
@@ -293,7 +293,7 @@ class Message:
         """
         Pins the message to the channel.
         """
-        return await self.client.http.pin_channel_message(self.channel_id, self.id)
+        return await self.client.http.pin_message(self.channel_id, self.id)
 
     async def unpin(self):
         """

--- a/discohook/message.py
+++ b/discohook/message.py
@@ -236,7 +236,7 @@ class Message:
         """
         Deletes the message.
         """
-        return await self.client.http.delete_channel_message(self.channel_id, self.id)
+        return await self.client.http.delete_message(self.channel_id, self.id)
 
     async def edit(
         self,

--- a/discohook/message.py
+++ b/discohook/message.py
@@ -299,7 +299,7 @@ class Message:
         """
         Unpins the message from the channel.
         """
-        return await self.client.http.unpin_channel_message(self.channel_id, self.id)
+        return await self.client.http.unpin_message(self.channel_id, self.id)
 
     async def reply(
         self,

--- a/discohook/message.py
+++ b/discohook/message.py
@@ -232,11 +232,11 @@ class Message:
     def position(self) -> Optional[int]:
         return self.data.get("position")
 
-    async def delete(self):
+    async def delete(self, *, reason: Optional[str] = None):
         """
         Deletes the message.
         """
-        return await self.client.http.delete_message(self.channel_id, self.id)
+        return await self.client.http.delete_message(self.channel_id, self.id, reason=reason)
 
     async def edit(
         self,
@@ -289,17 +289,17 @@ class Message:
         )
         return Message(self.client, await resp.json())
 
-    async def pin(self):
+    async def pin(self, *, reason: Optional[str] = None):
         """
         Pins the message to the channel.
         """
-        return await self.client.http.pin_message(self.channel_id, self.id)
+        return await self.client.http.pin_message(self.channel_id, self.id, reason=reason)
 
-    async def unpin(self):
+    async def unpin(self, *, reason: Optional[str] = None):
         """
         Unpins the message from the channel.
         """
-        return await self.client.http.unpin_message(self.channel_id, self.id)
+        return await self.client.http.unpin_message(self.channel_id, self.id, reason=reason)
 
     async def reply(
         self,

--- a/discohook/message.py
+++ b/discohook/message.py
@@ -382,7 +382,7 @@ class Message:
             encoded = f"{emoji.name}:{emoji.id}"
         else:
             encoded = "".join(f"%{byte:02x}" for byte in emoji.encode("utf-8"))
-        return await self.client.http.create_message_reaction(
+        return await self.client.http.create_reaction(
             self.channel_id, self.id, encoded
         )
 

--- a/discohook/role.py
+++ b/discohook/role.py
@@ -38,6 +38,7 @@ class PartialRole:
         description: Optional[str] = None,
         unicode_emoji: Optional[str] = None,
         icon_data_uri: Optional[str] = None,
+        reason: Optional[str] = None
     ) -> "Role":
         """
         Edits the role.
@@ -85,11 +86,17 @@ class PartialRole:
             payload["unicode_emoji"] = unicode_emoji
         if icon_data_uri:
             payload["icon"] = icon_data_uri
-        resp = await self.client.http.modify_guild_role(self.guild_id, self.id, payload)
+        resp = await self.client.http.modify_guild_role(self.guild_id, self.id, payload, reason=reason)
         data = await resp.json()
         return Role(self.client, data)
 
-    async def edit_position(self, role_id: str, *, position: int) -> List["Role"]:
+    async def edit_position(
+        self, 
+        role_id: str, 
+        *, 
+        position: int,
+        reason: Optional[str] = None 
+    ) -> List["Role"]:
         """
         Changes the position of the role.
         Parameters
@@ -104,7 +111,11 @@ class PartialRole:
         :class:`Role`
         """
         payload = {"id": role_id, "position": position}
-        resp = await self.client.http.modify_guild_role_positions(self.guild_id, payload)
+        resp = await self.client.http.modify_guild_role_positions(
+            self.guild_id, 
+            payload
+            reason=reason
+        )
         data = await resp.json()
         return [Role(self.client, role) for role in data]
 

--- a/discohook/role.py
+++ b/discohook/role.py
@@ -85,7 +85,7 @@ class PartialRole:
             payload["unicode_emoji"] = unicode_emoji
         if icon_data_uri:
             payload["icon"] = icon_data_uri
-        resp = await self.client.http.edit_guild_role(self.guild_id, self.id, payload)
+        resp = await self.client.http.modify_guild_role(self.guild_id, self.id, payload)
         data = await resp.json()
         return Role(self.client, data)
 

--- a/discohook/role.py
+++ b/discohook/role.py
@@ -104,7 +104,7 @@ class PartialRole:
         :class:`Role`
         """
         payload = {"id": role_id, "position": position}
-        resp = await self.client.http.edit_guild_role_position(self.guild_id, payload)
+        resp = await self.client.http.modify_guild_role_positions(self.guild_id, payload)
         data = await resp.json()
         return [Role(self.client, role) for role in data]
 

--- a/discohook/user.py
+++ b/discohook/user.py
@@ -162,5 +162,5 @@ class User:
             file=file,
             files=files,
         )
-        resp = await self.client.http.create_dm_channel({"recipient_id": self.id})
+        resp = await self.client.http.create_dm({"recipient_id": self.id})
         return await self.client.http.create_message((await resp.json())["id"], payload)

--- a/discohook/user.py
+++ b/discohook/user.py
@@ -163,4 +163,4 @@ class User:
             files=files,
         )
         resp = await self.client.http.create_dm_channel({"recipient_id": self.id})
-        return await self.client.http.send_message((await resp.json())["id"], payload)
+        return await self.client.http.create_message((await resp.json())["id"], payload)

--- a/discohook/webhook.py
+++ b/discohook/webhook.py
@@ -204,6 +204,7 @@ class Webhook:
         name: Optional[str] = None,
         image_base64: Optional[str] = None,
         channel_id: Optional[str] = None,
+        reason: Optional[str] = None
     ) -> "Webhook":
         """
         Edits the webhook.
@@ -232,7 +233,7 @@ class Webhook:
             payload["avatar"] = image_base64
         if channel_id:
             payload["channel_id"] = channel_id
-        resp = await self.client.http.edit_webhook(self.id, payload)
+        resp = await self.client.http.modify_webhook(self.id, payload, reason=reason)
         data = await resp.json()
         return Webhook(self.client, data)
 

--- a/discohook/webhook.py
+++ b/discohook/webhook.py
@@ -190,14 +190,14 @@ class Webhook:
         if data:
             return User(self.client, data)
 
-    async def delete(self):
+    async def delete(self, *, reason: Optional[str] = None):
         """
         Deletes the webhook.
         Returns
         -------
         None
         """
-        await self.client.http.delete_webhook(self.id)
+        await self.client.http.delete_webhook(self.id, reason=reason)
 
     async def edit(
         self,


### PR DESCRIPTION
Updates:
- lists all http methods with the same name
- add reason parameters to methods that are missing them

The last 9 functions are still to-do because:
- not sure what the way is to implement query strings (see purge)
- some functions merge methods together e.g. `delete_command`